### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/packages/app/build.gradle.kts
+++ b/packages/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.superdash"
         minSdk = 30
         targetSdk = 35
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = 2
+        versionName = "0.2.0"
 
         // Ship arm64-v8a only: modern tablets and Apple Silicon emulators.
         // Filters both the CMake-built libs and the prebuilt AAR native libs.


### PR DESCRIPTION
Version bump for the v0.2.0 release (Android 11 support).

https://claude.ai/code/session_01DpKP7VnGBKJchJZUi8atu7