### PR TITLE
feat: make the settings sidebar discoverable (pin by default + edge handle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ ESPHome native API, so HA can read and control the kiosk.
 
 ## Features
 
-- Shows a Home Assistant dashboard in kiosk mode.
-- Handles Home Assistant OAuth and token refresh.
-- Runs on-device wake word detection and sends captured speech to Home Assistant Assist.
-- Shows screensavers and doorbell camera overlays.
-- Exposes controls to Home Assistant through the ESPHome native API.
+- **Full-screen kiosk** — Your Home Assistant dashboard, edge-to-edge and always-on. Stays signed in across reboots.
+- **Hands-free voice** — On-device wake word detection sends your speech straight to Home Assistant Assist.
+- **Ambient screensaver** — Photo slideshow (Immich), clock overlay, and a night mode for idle hours.
+- **Doorbell overlays** — A live camera feed pops up when a doorbell rings.
+- **Two-way with Home Assistant** — Exposes the tablet back to HA over the ESPHome native API, so HA can read and control the kiosk.
+- **Customizable sidebar** — A rail of shortcuts (settings, reload, sleep/wake, night mode, jump to any dashboard view) pinned to any screen edge.
 
 ## Getting Started
 

--- a/packages/app/src/androidTest/kotlin/com/superdash/kiosk/ui/SidebarRailTest.kt
+++ b/packages/app/src/androidTest/kotlin/com/superdash/kiosk/ui/SidebarRailTest.kt
@@ -85,6 +85,7 @@ class SidebarRailTest {
                     pinned = false,
                     edgeHandle = false,
                     open = true,
+                    idle = false,
                     showLabels = false,
                     nightModeActive = false,
                     shortcuts = emptyList(),
@@ -119,6 +120,7 @@ class SidebarRailTest {
                     pinned = false,
                     edgeHandle = false,
                     open = true,
+                    idle = false,
                     showLabels = false,
                     nightModeActive = false,
                     shortcuts = listOf(shortcut),
@@ -147,6 +149,7 @@ class SidebarRailTest {
                     pinned = false,
                     edgeHandle = false,
                     open = false,
+                    idle = false,
                     showLabels = false,
                     nightModeActive = false,
                     shortcuts = emptyList(),
@@ -173,6 +176,7 @@ class SidebarRailTest {
                     pinned = true,
                     edgeHandle = false,
                     open = true,
+                    idle = false,
                     showLabels = false,
                     nightModeActive = false,
                     shortcuts = emptyList(),
@@ -199,6 +203,7 @@ class SidebarRailTest {
                     pinned = false,
                     edgeHandle = true,
                     open = false,
+                    idle = false,
                     showLabels = false,
                     nightModeActive = false,
                     shortcuts = emptyList(),
@@ -224,6 +229,7 @@ class SidebarRailTest {
                     pinned = false,
                     edgeHandle = false,
                     open = false,
+                    idle = false,
                     showLabels = false,
                     nightModeActive = false,
                     shortcuts = emptyList(),
@@ -249,6 +255,7 @@ class SidebarRailTest {
                     pinned = true,
                     edgeHandle = true,
                     open = false,
+                    idle = false,
                     showLabels = false,
                     nightModeActive = false,
                     shortcuts = emptyList(),
@@ -275,6 +282,7 @@ class SidebarRailTest {
                     pinned = false,
                     edgeHandle = true,
                     open = false,
+                    idle = false,
                     showLabels = false,
                     nightModeActive = false,
                     shortcuts = emptyList(),
@@ -290,5 +298,65 @@ class SidebarRailTest {
 
         composeRule.onNodeWithContentDescription("Open sidebar").performClick()
         composeRule.runOnIdle { assert(opened) }
+    }
+
+    @Test
+    fun idleHidesPinnedRail() {
+        val shortcut =
+            SidebarShortcut(
+                id = "settings",
+                title = "Settings",
+                icon = "settings",
+                action = SidebarAction.OpenSettings,
+            )
+
+        composeRule.setContent {
+            MaterialTheme {
+                SidebarRailLayout(
+                    position = SidebarPosition.Left,
+                    pinned = true,
+                    edgeHandle = false,
+                    open = false,
+                    idle = true,
+                    showLabels = false,
+                    nightModeActive = false,
+                    shortcuts = listOf(shortcut),
+                    onOpen = {},
+                    onDismiss = {},
+                    onPinnedChange = {},
+                    onShortcutClick = {},
+                    content = { Box {} },
+                    overlays = {},
+                )
+            }
+        }
+
+        composeRule.onAllNodesWithContentDescription("Settings").assertCountEquals(0)
+    }
+
+    @Test
+    fun idleHidesEdgeHandle() {
+        composeRule.setContent {
+            MaterialTheme {
+                SidebarRailLayout(
+                    position = SidebarPosition.Left,
+                    pinned = false,
+                    edgeHandle = true,
+                    open = false,
+                    idle = true,
+                    showLabels = false,
+                    nightModeActive = false,
+                    shortcuts = emptyList(),
+                    onOpen = {},
+                    onDismiss = {},
+                    onPinnedChange = {},
+                    onShortcutClick = {},
+                    content = { Box {} },
+                    overlays = {},
+                )
+            }
+        }
+
+        composeRule.onAllNodesWithContentDescription("Open sidebar").assertCountEquals(0)
     }
 }

--- a/packages/app/src/androidTest/kotlin/com/superdash/kiosk/ui/SidebarRailTest.kt
+++ b/packages/app/src/androidTest/kotlin/com/superdash/kiosk/ui/SidebarRailTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.superdash.kiosk.SidebarAction
 import com.superdash.kiosk.SidebarPosition
@@ -82,6 +83,7 @@ class SidebarRailTest {
                 SidebarRailLayout(
                     position = SidebarPosition.Left,
                     pinned = false,
+                    edgeHandle = false,
                     open = true,
                     showLabels = false,
                     nightModeActive = false,
@@ -115,6 +117,7 @@ class SidebarRailTest {
                 SidebarRailLayout(
                     position = SidebarPosition.Left,
                     pinned = false,
+                    edgeHandle = false,
                     open = true,
                     showLabels = false,
                     nightModeActive = false,
@@ -142,6 +145,7 @@ class SidebarRailTest {
                 SidebarRailLayout(
                     position = SidebarPosition.Left,
                     pinned = false,
+                    edgeHandle = false,
                     open = false,
                     showLabels = false,
                     nightModeActive = false,
@@ -167,6 +171,7 @@ class SidebarRailTest {
                 SidebarRailLayout(
                     position = SidebarPosition.Left,
                     pinned = true,
+                    edgeHandle = false,
                     open = true,
                     showLabels = false,
                     nightModeActive = false,
@@ -183,5 +188,107 @@ class SidebarRailTest {
 
         composeRule.onAllNodesWithText("Background action").assertCountEquals(1)
         composeRule.onAllNodesWithText("Overlay action").assertCountEquals(1)
+    }
+
+    @Test
+    fun unpinnedClosedSidebarWithHandleShowsHandle() {
+        composeRule.setContent {
+            MaterialTheme {
+                SidebarRailLayout(
+                    position = SidebarPosition.Left,
+                    pinned = false,
+                    edgeHandle = true,
+                    open = false,
+                    showLabels = false,
+                    nightModeActive = false,
+                    shortcuts = emptyList(),
+                    onOpen = {},
+                    onDismiss = {},
+                    onPinnedChange = {},
+                    onShortcutClick = {},
+                    content = { Box {} },
+                    overlays = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Open sidebar").assertHasClickAction()
+    }
+
+    @Test
+    fun unpinnedClosedSidebarWithoutHandleHidesHandle() {
+        composeRule.setContent {
+            MaterialTheme {
+                SidebarRailLayout(
+                    position = SidebarPosition.Left,
+                    pinned = false,
+                    edgeHandle = false,
+                    open = false,
+                    showLabels = false,
+                    nightModeActive = false,
+                    shortcuts = emptyList(),
+                    onOpen = {},
+                    onDismiss = {},
+                    onPinnedChange = {},
+                    onShortcutClick = {},
+                    content = { Box {} },
+                    overlays = {},
+                )
+            }
+        }
+
+        composeRule.onAllNodesWithContentDescription("Open sidebar").assertCountEquals(0)
+    }
+
+    @Test
+    fun pinnedSidebarHidesHandle() {
+        composeRule.setContent {
+            MaterialTheme {
+                SidebarRailLayout(
+                    position = SidebarPosition.Left,
+                    pinned = true,
+                    edgeHandle = true,
+                    open = false,
+                    showLabels = false,
+                    nightModeActive = false,
+                    shortcuts = emptyList(),
+                    onOpen = {},
+                    onDismiss = {},
+                    onPinnedChange = {},
+                    onShortcutClick = {},
+                    content = { Box {} },
+                    overlays = {},
+                )
+            }
+        }
+
+        composeRule.onAllNodesWithContentDescription("Open sidebar").assertCountEquals(0)
+    }
+
+    @Test
+    fun tappingHandleOpensSidebar() {
+        var opened = false
+        composeRule.setContent {
+            MaterialTheme {
+                SidebarRailLayout(
+                    position = SidebarPosition.Left,
+                    pinned = false,
+                    edgeHandle = true,
+                    open = false,
+                    showLabels = false,
+                    nightModeActive = false,
+                    shortcuts = emptyList(),
+                    onOpen = { opened = true },
+                    onDismiss = {},
+                    onPinnedChange = {},
+                    onShortcutClick = {},
+                    content = { Box {} },
+                    overlays = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Open sidebar").performClick()
+        composeRule.runOnIdle { assert(opened) }
     }
 }

--- a/packages/app/src/androidTest/kotlin/com/superdash/settings/SettingsActionFixtures.kt
+++ b/packages/app/src/androidTest/kotlin/com/superdash/settings/SettingsActionFixtures.kt
@@ -81,6 +81,7 @@ internal fun testSettingsActions(): SettingsActions =
                 onPositionChange = {},
                 onPinnedChange = {},
                 onShowLabelsChange = {},
+                onEdgeHandleChange = {},
                 onShortcutsChange = {},
             ),
         admin =

--- a/packages/app/src/main/kotlin/com/superdash/MainActivity.kt
+++ b/packages/app/src/main/kotlin/com/superdash/MainActivity.kt
@@ -316,6 +316,7 @@ private fun MainContent(
             pinned = state.sidebar.pinned,
             edgeHandle = state.sidebar.edgeHandle,
             open = sidebarOpen,
+            idle = state.isIdle,
             showLabels = state.sidebar.showLabels,
             nightModeActive = state.nightModeActive,
             shortcuts = state.sidebar.shortcuts,

--- a/packages/app/src/main/kotlin/com/superdash/MainActivity.kt
+++ b/packages/app/src/main/kotlin/com/superdash/MainActivity.kt
@@ -314,6 +314,7 @@ private fun MainContent(
         SidebarRailLayout(
             position = state.sidebar.position,
             pinned = state.sidebar.pinned,
+            edgeHandle = state.sidebar.edgeHandle,
             open = sidebarOpen,
             showLabels = state.sidebar.showLabels,
             nightModeActive = state.nightModeActive,

--- a/packages/app/src/main/kotlin/com/superdash/MainUiState.kt
+++ b/packages/app/src/main/kotlin/com/superdash/MainUiState.kt
@@ -46,8 +46,8 @@ data class SidebarUiState(
     val position: SidebarPosition,
     val pinned: Boolean,
     val showLabels: Boolean,
-    val shortcuts: ImmutableList<SidebarShortcut>,
     val edgeHandle: Boolean,
+    val shortcuts: ImmutableList<SidebarShortcut>,
 ) {
     companion object {
         fun empty(): SidebarUiState =
@@ -55,8 +55,8 @@ data class SidebarUiState(
                 position = SidebarSettingsDefaults.position,
                 pinned = SidebarSettingsDefaults.pinned,
                 showLabels = SidebarSettingsDefaults.showLabels,
-                shortcuts = SidebarSettingsDefaults.shortcuts.toImmutableList(),
                 edgeHandle = SidebarSettingsDefaults.edgeHandle,
+                shortcuts = SidebarSettingsDefaults.shortcuts.toImmutableList(),
             )
     }
 }

--- a/packages/app/src/main/kotlin/com/superdash/MainUiState.kt
+++ b/packages/app/src/main/kotlin/com/superdash/MainUiState.kt
@@ -47,6 +47,7 @@ data class SidebarUiState(
     val pinned: Boolean,
     val showLabels: Boolean,
     val shortcuts: ImmutableList<SidebarShortcut>,
+    val edgeHandle: Boolean,
 ) {
     companion object {
         fun empty(): SidebarUiState =
@@ -55,6 +56,7 @@ data class SidebarUiState(
                 pinned = SidebarSettingsDefaults.pinned,
                 showLabels = SidebarSettingsDefaults.showLabels,
                 shortcuts = SidebarSettingsDefaults.shortcuts.toImmutableList(),
+                edgeHandle = SidebarSettingsDefaults.edgeHandle,
             )
     }
 }

--- a/packages/app/src/main/kotlin/com/superdash/MainViewModel.kt
+++ b/packages/app/src/main/kotlin/com/superdash/MainViewModel.kt
@@ -36,6 +36,7 @@ class MainViewModel(
     sidebarPinnedFlow: Flow<Boolean>,
     sidebarShowLabelsFlow: Flow<Boolean>,
     sidebarShortcutsFlow: Flow<List<SidebarShortcut>>,
+    sidebarEdgeHandleFlow: Flow<Boolean>,
 ) : ViewModel() {
     private val connectionFlow =
         combine(haUrlFlow, dashboardPathFlow, tokensFlow, haStateFlow) { haUrl, dashboardPath, tokens, haState ->
@@ -78,12 +79,14 @@ class MainViewModel(
             sidebarPinnedFlow,
             sidebarShowLabelsFlow,
             sidebarShortcutsFlow,
-        ) { position, pinned, showLabels, shortcuts ->
+            sidebarEdgeHandleFlow,
+        ) { position, pinned, showLabels, shortcuts, edgeHandle ->
             SidebarUiState(
                 position = position,
                 pinned = pinned,
                 showLabels = showLabels,
                 shortcuts = shortcuts.toImmutableList(),
+                edgeHandle = edgeHandle,
             )
         }
 
@@ -177,6 +180,7 @@ class MainViewModel(
                 sidebarPinnedFlow = graph.sidebarSettings.pinned,
                 sidebarShowLabelsFlow = graph.sidebarSettings.showLabels,
                 sidebarShortcutsFlow = graph.sidebarSettings.shortcuts,
+                sidebarEdgeHandleFlow = graph.sidebarSettings.edgeHandle,
             ) as T
     }
 }

--- a/packages/app/src/main/kotlin/com/superdash/MainViewModel.kt
+++ b/packages/app/src/main/kotlin/com/superdash/MainViewModel.kt
@@ -85,8 +85,8 @@ class MainViewModel(
                 position = position,
                 pinned = pinned,
                 showLabels = showLabels,
-                shortcuts = shortcuts.toImmutableList(),
                 edgeHandle = edgeHandle,
+                shortcuts = shortcuts.toImmutableList(),
             )
         }
 

--- a/packages/app/src/main/kotlin/com/superdash/kiosk/SidebarSettings.kt
+++ b/packages/app/src/main/kotlin/com/superdash/kiosk/SidebarSettings.kt
@@ -13,6 +13,8 @@ interface SidebarSettings {
 
     val showLabels: Flow<Boolean>
 
+    val edgeHandle: Flow<Boolean>
+
     val shortcuts: Flow<List<SidebarShortcut>>
 
     suspend fun setPosition(value: SidebarPosition)
@@ -20,6 +22,8 @@ interface SidebarSettings {
     suspend fun setPinned(value: Boolean)
 
     suspend fun setShowLabels(value: Boolean)
+
+    suspend fun setEdgeHandle(value: Boolean)
 
     suspend fun setShortcuts(value: List<SidebarShortcut>)
 }
@@ -128,9 +132,11 @@ internal fun SidebarShortcut.selectedInSidebar(nightModeActive: Boolean): Boolea
 object SidebarSettingsDefaults {
     val position: SidebarPosition = SidebarPosition.Left
 
-    val pinned: Boolean = false
+    val pinned: Boolean = true
 
     val showLabels: Boolean = false
+
+    val edgeHandle: Boolean = true
 
     val settingsShortcut =
         SidebarShortcut(

--- a/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
+++ b/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
@@ -389,8 +389,7 @@ private fun SidebarEdgeHandle(
                     } else {
                         Modifier.height(edgeHandleTouchThickness).width(edgeHandleLength)
                     },
-                )
-                .clickable(onClickLabel = description, onClick = onOpen)
+                ).clickable(onClickLabel = description, onClick = onOpen)
                 .semantics { contentDescription = description },
         contentAlignment = Alignment.Center,
     ) {

--- a/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
+++ b/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -61,8 +61,9 @@ private val compactButtonSize = 48.dp
 private val labeledItemWidth = 84.dp
 private val labeledItemHeight = 64.dp
 private val edgeHandleTouchThickness = 48.dp
-private val edgeHandleLength = 48.dp
-private val edgeHandleThickness = 6.dp
+private val edgeHandleDotSize = 4.dp
+private val edgeHandleDotSpacing = 6.dp
+private val edgeHandleEdgeInset = 10.dp
 
 @Composable
 fun SidebarRailLayout(
@@ -382,33 +383,64 @@ private fun SidebarEdgeHandle(
 ) {
     val isVertical = position == SidebarPosition.Left || position == SidebarPosition.Right
     val description = stringResource(R.string.sidebar_open_content_description)
+    val dotColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+    // Sit the grip near the bezel so it reads as attached to the hidden rail's edge.
+    val edgeAlignment =
+        when (position) {
+            SidebarPosition.Left -> Alignment.CenterStart
+            SidebarPosition.Right -> Alignment.CenterEnd
+            SidebarPosition.Top -> Alignment.TopCenter
+            SidebarPosition.Bottom -> Alignment.BottomCenter
+        }
+    val insetPadding =
+        when (position) {
+            SidebarPosition.Left -> Modifier.padding(start = edgeHandleEdgeInset)
+            SidebarPosition.Right -> Modifier.padding(end = edgeHandleEdgeInset)
+            SidebarPosition.Top -> Modifier.padding(top = edgeHandleEdgeInset)
+            SidebarPosition.Bottom -> Modifier.padding(bottom = edgeHandleEdgeInset)
+        }
     Box(
         modifier =
             modifier
                 .then(
                     if (isVertical) {
-                        Modifier.width(edgeHandleTouchThickness).height(edgeHandleLength)
+                        Modifier.width(edgeHandleTouchThickness).height(edgeHandleTouchThickness)
                     } else {
-                        Modifier.height(edgeHandleTouchThickness).width(edgeHandleLength)
+                        Modifier.height(edgeHandleTouchThickness).width(edgeHandleTouchThickness)
                     },
                 ).clickable(onClickLabel = description, onClick = onOpen)
                 .semantics { contentDescription = description },
-        contentAlignment = Alignment.Center,
+        contentAlignment = edgeAlignment,
     ) {
-        Box(
-            modifier =
-                (
-                    if (isVertical) {
-                        Modifier.width(edgeHandleThickness).height(edgeHandleLength)
-                    } else {
-                        Modifier.height(edgeHandleThickness).width(edgeHandleLength)
-                    }
-                ).background(
-                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
-                    shape = RoundedCornerShape(edgeHandleThickness / 2),
-                ),
-        )
+        // Three dots in drag-handle grammar: reads as a "grab" affordance, not a scrollbar.
+        if (isVertical) {
+            Column(
+                modifier = insetPadding,
+                verticalArrangement = Arrangement.spacedBy(edgeHandleDotSpacing),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                repeat(3) { EdgeHandleDot(dotColor) }
+            }
+        } else {
+            Row(
+                modifier = insetPadding,
+                horizontalArrangement = Arrangement.spacedBy(edgeHandleDotSpacing),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                repeat(3) { EdgeHandleDot(dotColor) }
+            }
+        }
     }
+}
+
+@Composable
+private fun EdgeHandleDot(color: Color) {
+    Box(
+        modifier =
+            Modifier
+                .size(edgeHandleDotSize)
+                .background(color = color, shape = CircleShape),
+    )
 }
 
 private val SidebarPosition.alignment: Alignment

--- a/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
+++ b/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -59,11 +60,15 @@ private val labeledRailSize = 96.dp
 private val compactButtonSize = 48.dp
 private val labeledItemWidth = 84.dp
 private val labeledItemHeight = 64.dp
+private val edgeHandleTouchThickness = 24.dp
+private val edgeHandleLength = 48.dp
+private val edgeHandleThickness = 6.dp
 
 @Composable
 fun SidebarRailLayout(
     position: SidebarPosition,
     pinned: Boolean,
+    edgeHandle: Boolean,
     open: Boolean,
     showLabels: Boolean,
     nightModeActive: Boolean,
@@ -135,6 +140,12 @@ fun SidebarRailLayout(
                 shortcuts = shortcuts,
                 onPinnedChange = onPinnedChange,
                 onShortcutClick = onShortcutClick,
+                modifier = Modifier.align(position.alignment),
+            )
+        } else if (edgeHandle) {
+            SidebarEdgeHandle(
+                position = position,
+                onOpen = onOpen,
                 modifier = Modifier.align(position.alignment),
             )
         }
@@ -357,6 +368,44 @@ private fun PinButton(
                     Icons.Filled.PushPin
                 },
             contentDescription = contentDesc,
+        )
+    }
+}
+
+@Composable
+private fun SidebarEdgeHandle(
+    position: SidebarPosition,
+    onOpen: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isVertical = position == SidebarPosition.Left || position == SidebarPosition.Right
+    val description = stringResource(R.string.sidebar_open_content_description)
+    Box(
+        modifier =
+            modifier
+                .then(
+                    if (isVertical) {
+                        Modifier.width(edgeHandleTouchThickness).height(edgeHandleLength)
+                    } else {
+                        Modifier.height(edgeHandleTouchThickness).width(edgeHandleLength)
+                    },
+                )
+                .clickable(onClickLabel = description, onClick = onOpen)
+                .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier =
+                (
+                    if (isVertical) {
+                        Modifier.width(edgeHandleThickness).height(edgeHandleLength)
+                    } else {
+                        Modifier.height(edgeHandleThickness).width(edgeHandleLength)
+                    }
+                ).background(
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+                    shape = RoundedCornerShape(edgeHandleThickness / 2),
+                ),
         )
     }
 }

--- a/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
+++ b/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
@@ -60,7 +60,7 @@ private val labeledRailSize = 96.dp
 private val compactButtonSize = 48.dp
 private val labeledItemWidth = 84.dp
 private val labeledItemHeight = 64.dp
-private val edgeHandleTouchThickness = 24.dp
+private val edgeHandleTouchThickness = 48.dp
 private val edgeHandleLength = 48.dp
 private val edgeHandleThickness = 6.dp
 

--- a/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
+++ b/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
@@ -70,6 +70,7 @@ fun SidebarRailLayout(
     pinned: Boolean,
     edgeHandle: Boolean,
     open: Boolean,
+    idle: Boolean,
     showLabels: Boolean,
     nightModeActive: Boolean,
     shortcuts: List<SidebarShortcut>,
@@ -112,7 +113,8 @@ fun SidebarRailLayout(
         ) {
             overlays()
         }
-        if (pinned) {
+        // While the screensaver is showing (idle) the sidebar and edge handle stay hidden.
+        if (!idle && pinned) {
             SidebarRail(
                 position = position,
                 pinned = true,
@@ -123,7 +125,7 @@ fun SidebarRailLayout(
                 onShortcutClick = onShortcutClick,
                 modifier = Modifier.align(position.alignment),
             )
-        } else if (open) {
+        } else if (!idle && open) {
             val dismissSidebarDescription = stringResource(R.string.sidebar_dismiss_content_description)
             Box(
                 modifier =
@@ -142,7 +144,7 @@ fun SidebarRailLayout(
                 onShortcutClick = onShortcutClick,
                 modifier = Modifier.align(position.alignment),
             )
-        } else if (edgeHandle) {
+        } else if (!idle && edgeHandle) {
             SidebarEdgeHandle(
                 position = position,
                 onOpen = onOpen,

--- a/packages/app/src/main/kotlin/com/superdash/settings/SettingsActivity.kt
+++ b/packages/app/src/main/kotlin/com/superdash/settings/SettingsActivity.kt
@@ -153,6 +153,7 @@ data class SidebarSettingsActions(
     val onPositionChange: (SidebarPosition) -> Unit,
     val onPinnedChange: (Boolean) -> Unit,
     val onShowLabelsChange: (Boolean) -> Unit,
+    val onEdgeHandleChange: (Boolean) -> Unit,
     val onShortcutsChange: (List<SidebarShortcut>) -> Unit,
 )
 
@@ -388,6 +389,7 @@ private fun SettingsScreen(
                         onPositionChange = settingsViewModel::setSidebarPosition,
                         onPinnedChange = settingsViewModel::setSidebarPinned,
                         onShowLabelsChange = settingsViewModel::setSidebarShowLabels,
+                        onEdgeHandleChange = settingsViewModel::setSidebarEdgeHandle,
                         onShortcutsChange = settingsViewModel::setSidebarShortcuts,
                     ),
                 admin =

--- a/packages/app/src/main/kotlin/com/superdash/settings/SettingsRepositorySidebarSettings.kt
+++ b/packages/app/src/main/kotlin/com/superdash/settings/SettingsRepositorySidebarSettings.kt
@@ -28,6 +28,8 @@ internal class SettingsRepositorySidebarSettings(
 
     override val showLabels: Flow<Boolean> = store.observe(SHOW_LABELS)
 
+    override val edgeHandle: Flow<Boolean> = store.observe(EDGE_HANDLE)
+
     override val shortcuts: Flow<List<SidebarShortcut>> =
         store.observe(SHORTCUTS_JSON).map { value -> decodeShortcuts(value) }
 
@@ -36,6 +38,8 @@ internal class SettingsRepositorySidebarSettings(
     override suspend fun setPinned(value: Boolean) = store.write(PINNED, value)
 
     override suspend fun setShowLabels(value: Boolean) = store.write(SHOW_LABELS, value)
+
+    override suspend fun setEdgeHandle(value: Boolean) = store.write(EDGE_HANDLE, value)
 
     override suspend fun setShortcuts(value: List<SidebarShortcut>) {
         store.write(SHORTCUTS_JSON, encodeShortcuts(value))
@@ -117,6 +121,7 @@ internal class SettingsRepositorySidebarSettings(
             )
         val PINNED = Setting(key = "sidebar.pinned", default = SidebarSettingsDefaults.pinned)
         val SHOW_LABELS = Setting(key = "sidebar.showLabels", default = SidebarSettingsDefaults.showLabels)
+        val EDGE_HANDLE = Setting(key = "sidebar.edgeHandle", default = SidebarSettingsDefaults.edgeHandle)
         val generatedShortLabels =
             setOf(
                 SidebarAction.OpenSettings.defaultShortLabel,

--- a/packages/app/src/main/kotlin/com/superdash/settings/SettingsUiState.kt
+++ b/packages/app/src/main/kotlin/com/superdash/settings/SettingsUiState.kt
@@ -249,6 +249,7 @@ data class SidebarSettingsState(
     val position: SidebarPosition,
     val pinned: Boolean,
     val showLabels: Boolean,
+    val edgeHandle: Boolean,
     val shortcuts: ImmutableList<SidebarShortcut>,
 ) {
     companion object {
@@ -257,6 +258,7 @@ data class SidebarSettingsState(
                 position = SidebarSettingsDefaults.position,
                 pinned = SidebarSettingsDefaults.pinned,
                 showLabels = SidebarSettingsDefaults.showLabels,
+                edgeHandle = SidebarSettingsDefaults.edgeHandle,
                 shortcuts = SidebarSettingsDefaults.shortcuts.toImmutableList(),
             )
     }

--- a/packages/app/src/main/kotlin/com/superdash/settings/SettingsViewModel.kt
+++ b/packages/app/src/main/kotlin/com/superdash/settings/SettingsViewModel.kt
@@ -267,12 +267,14 @@ class SettingsViewModel(
             sidebarSettings.pinned,
             sidebarSettings.showLabels,
             sidebarSettings.shortcuts,
-        ) { position, pinned, showLabels, shortcuts ->
+            sidebarSettings.edgeHandle,
+        ) { position, pinned, showLabels, shortcuts, edgeHandle ->
             SidebarSettingsState(
                 position = position,
                 pinned = pinned,
                 showLabels = showLabels,
                 shortcuts = shortcuts.toImmutableList(),
+                edgeHandle = edgeHandle,
             )
         }
 
@@ -487,6 +489,8 @@ class SettingsViewModel(
     fun setSidebarPinned(value: Boolean) = launch { sidebarSettings.setPinned(value) }
 
     fun setSidebarShowLabels(value: Boolean) = launch { sidebarSettings.setShowLabels(value) }
+
+    fun setSidebarEdgeHandle(value: Boolean) = launch { sidebarSettings.setEdgeHandle(value) }
 
     fun setSidebarShortcuts(value: List<SidebarShortcut>) = launch { sidebarSettings.setShortcuts(value) }
 

--- a/packages/app/src/main/kotlin/com/superdash/settings/ui/SidebarSettingsSection.kt
+++ b/packages/app/src/main/kotlin/com/superdash/settings/ui/SidebarSettingsSection.kt
@@ -69,6 +69,12 @@ fun SidebarSettingsSection(
         onCheckedChange = actions.onShowLabelsChange,
         supportingText = stringResource(R.string.settings_sidebar_show_labels_summary),
     )
+    SettingsSwitchRow(
+        label = stringResource(R.string.settings_sidebar_edge_handle_label),
+        checked = state.edgeHandle,
+        onCheckedChange = actions.onEdgeHandleChange,
+        supportingText = stringResource(R.string.settings_sidebar_edge_handle_summary),
+    )
     state.shortcuts.forEachIndexed { index, shortcut ->
         val isSettingsShortcut = shortcut.action is SidebarAction.OpenSettings
         val previousShortcut = state.shortcuts.getOrNull(index - 1)

--- a/packages/app/src/main/res/values/strings.xml
+++ b/packages/app/src/main/res/values/strings.xml
@@ -248,6 +248,7 @@
 
     <!-- Sidebar overlay -->
     <string name="sidebar_dismiss_content_description">Dismiss sidebar</string>
+    <string name="sidebar_open_content_description">Open sidebar</string>
     <string name="sidebar_unpin_content_description">Unpin sidebar</string>
     <string name="sidebar_pin_content_description">Pin sidebar</string>
     <string name="sidebar_item_active_content_description">%1$s, active</string>

--- a/packages/app/src/main/res/values/strings.xml
+++ b/packages/app/src/main/res/values/strings.xml
@@ -144,6 +144,8 @@
     <string name="settings_sidebar_pinned_summary">Pinned sidebars reserve dashboard space.</string>
     <string name="settings_sidebar_show_labels_label">Show labels</string>
     <string name="settings_sidebar_show_labels_summary">Shows short text under each sidebar icon.</string>
+    <string name="settings_sidebar_edge_handle_label">Edge handle</string>
+    <string name="settings_sidebar_edge_handle_summary">Shows a small tab to open an unpinned sidebar.</string>
     <string name="settings_sidebar_add_shortcut_button">Add shortcut</string>
     <string name="settings_sidebar_edit_shortcut_title">Edit shortcut</string>
     <string name="settings_sidebar_add_shortcut_title">Add shortcut</string>

--- a/packages/app/src/test/kotlin/com/superdash/MainViewModelTest.kt
+++ b/packages/app/src/test/kotlin/com/superdash/MainViewModelTest.kt
@@ -67,6 +67,7 @@ class MainViewModelTest {
         val sidebarPinned = MutableStateFlow(false)
         val sidebarShowLabels = MutableStateFlow(false)
         val sidebarShortcuts = MutableStateFlow(SidebarSettingsDefaults.shortcuts)
+        val sidebarEdgeHandle = MutableStateFlow(SidebarSettingsDefaults.edgeHandle)
 
         val viewModel =
             MainViewModel(
@@ -86,6 +87,7 @@ class MainViewModelTest {
                 sidebarPinnedFlow = sidebarPinned,
                 sidebarShowLabelsFlow = sidebarShowLabels,
                 sidebarShortcutsFlow = sidebarShortcuts,
+                sidebarEdgeHandleFlow = sidebarEdgeHandle,
             )
 
         return viewModel to Inputs(haUrl, tokens, haState, voiceEnabled, doorbellState)
@@ -234,6 +236,7 @@ class MainViewModelTest {
             val sidebarPinned = MutableStateFlow(true)
             val sidebarShowLabels = MutableStateFlow(true)
             val sidebarShortcuts = MutableStateFlow(SidebarSettingsDefaults.shortcuts.take(1))
+            val sidebarEdgeHandle = MutableStateFlow(false)
             val viewModel =
                 MainViewModel(
                     haUrlFlow = haUrl,
@@ -252,6 +255,7 @@ class MainViewModelTest {
                     sidebarPinnedFlow = sidebarPinned,
                     sidebarShowLabelsFlow = sidebarShowLabels,
                     sidebarShortcutsFlow = sidebarShortcuts,
+                    sidebarEdgeHandleFlow = sidebarEdgeHandle,
                 )
 
             backgroundScope.launch { viewModel.uiState.collect {} }
@@ -261,5 +265,6 @@ class MainViewModelTest {
             assertEquals(true, viewModel.uiState.value.sidebar.pinned)
             assertEquals(true, viewModel.uiState.value.sidebar.showLabels)
             assertEquals(SidebarSettingsDefaults.shortcuts.take(1), viewModel.uiState.value.sidebar.shortcuts)
+            assertEquals(false, viewModel.uiState.value.sidebar.edgeHandle)
         }
 }

--- a/packages/app/src/test/kotlin/com/superdash/MainViewModelViewActivationTest.kt
+++ b/packages/app/src/test/kotlin/com/superdash/MainViewModelViewActivationTest.kt
@@ -100,6 +100,7 @@ class MainViewModelViewActivationTest {
                 sidebarPinnedFlow = MutableStateFlow(false),
                 sidebarShowLabelsFlow = MutableStateFlow(false),
                 sidebarShortcutsFlow = MutableStateFlow(SidebarSettingsDefaults.shortcuts),
+                sidebarEdgeHandleFlow = MutableStateFlow(SidebarSettingsDefaults.edgeHandle),
             )
         return viewModel to flows
     }

--- a/packages/app/src/test/kotlin/com/superdash/settings/SettingsRepositorySidebarSettingsTest.kt
+++ b/packages/app/src/test/kotlin/com/superdash/settings/SettingsRepositorySidebarSettingsTest.kt
@@ -17,16 +17,29 @@ class SettingsRepositorySidebarSettingsTest {
             assertEquals(SidebarPosition.Left, settings.position.first())
         }
 
-    @Test fun `pinned defaults to false`() =
+    @Test fun `pinned defaults to true`() =
         runTest {
             val settings = SettingsRepositorySidebarSettings(InMemoryKeyValueStore())
-            assertEquals(false, settings.pinned.first())
+            assertEquals(true, settings.pinned.first())
         }
 
     @Test fun `showLabels defaults to false`() =
         runTest {
             val settings = SettingsRepositorySidebarSettings(InMemoryKeyValueStore())
             assertEquals(false, settings.showLabels.first())
+        }
+
+    @Test fun `edgeHandle defaults to true`() =
+        runTest {
+            val settings = SettingsRepositorySidebarSettings(InMemoryKeyValueStore())
+            assertEquals(true, settings.edgeHandle.first())
+        }
+
+    @Test fun `setEdgeHandle stores edge handle value`() =
+        runTest {
+            val settings = SettingsRepositorySidebarSettings(InMemoryKeyValueStore())
+            settings.setEdgeHandle(false)
+            assertEquals(false, settings.edgeHandle.first())
         }
 
     @Test fun `setShowLabels stores show label value`() =

--- a/packages/app/src/test/kotlin/com/superdash/settings/SettingsViewModelTest.kt
+++ b/packages/app/src/test/kotlin/com/superdash/settings/SettingsViewModelTest.kt
@@ -582,15 +582,18 @@ class SettingsViewModelTest {
         shortcutsFlow: MutableStateFlow<List<SidebarShortcut>> = MutableStateFlow(SidebarSettingsDefaults.shortcuts),
     ) : SidebarSettings {
         val showLabelsValue = MutableStateFlow(false)
+        val edgeHandleValue = MutableStateFlow(true)
 
         override val position: Flow<SidebarPosition> = positionFlow.asStateFlow()
         override val pinned: Flow<Boolean> = pinnedFlow.asStateFlow()
         override val showLabels: Flow<Boolean> = showLabelsValue
+        override val edgeHandle: Flow<Boolean> = edgeHandleValue
         override val shortcuts: Flow<List<SidebarShortcut>> = shortcutsFlow.asStateFlow()
 
         var lastPosition: SidebarPosition? = null
         var lastPinned: Boolean? = null
         var lastShowLabels: Boolean? = null
+        var lastEdgeHandle: Boolean? = null
         var lastShortcuts: List<SidebarShortcut>? = null
 
         override suspend fun setPosition(value: SidebarPosition) {
@@ -604,6 +607,11 @@ class SettingsViewModelTest {
         override suspend fun setShowLabels(value: Boolean) {
             lastShowLabels = value
             showLabelsValue.value = value
+        }
+
+        override suspend fun setEdgeHandle(value: Boolean) {
+            lastEdgeHandle = value
+            edgeHandleValue.value = value
         }
 
         override suspend fun setShortcuts(value: List<SidebarShortcut>) {

--- a/packages/app/src/test/kotlin/com/superdash/settings/SettingsViewModelTest.kt
+++ b/packages/app/src/test/kotlin/com/superdash/settings/SettingsViewModelTest.kt
@@ -510,6 +510,7 @@ class SettingsViewModelTest {
                     shortcutsFlow = MutableStateFlow(SidebarSettingsDefaults.shortcuts.take(2)),
                 )
             sidebar.showLabelsValue.value = true
+            sidebar.edgeHandleValue.value = false
             val viewModel = buildViewModel(sidebar = sidebar)
             backgroundScope.launch { viewModel.uiState.collect {} }
             advanceUntilIdle()
@@ -517,6 +518,7 @@ class SettingsViewModelTest {
             assertEquals(SidebarPosition.Top, viewModel.uiState.value.sidebar.position)
             assertEquals(true, viewModel.uiState.value.sidebar.pinned)
             assertEquals(true, viewModel.uiState.value.sidebar.showLabels)
+            assertEquals(false, viewModel.uiState.value.sidebar.edgeHandle)
             assertEquals(SidebarSettingsDefaults.shortcuts.take(2), viewModel.uiState.value.sidebar.shortcuts)
         }
 
@@ -546,6 +548,18 @@ class SettingsViewModelTest {
             advanceUntilIdle()
 
             assertEquals(true, sidebar.lastShowLabels)
+        }
+
+    @Test
+    fun `setSidebarEdgeHandle delegates to sidebar settings`() =
+        runTest {
+            val sidebar = FakeSidebarSettings()
+            val viewModel = buildViewModel(sidebar = sidebar)
+
+            viewModel.setSidebarEdgeHandle(false)
+            advanceUntilIdle()
+
+            assertEquals(false, sidebar.lastEdgeHandle)
         }
 
     private class FakeKioskSettings(


### PR DESCRIPTION
## Why

New users (e.g. from the Reddit launch) open superdash, see only the full-screen Home Assistant dashboard, and never discover the **Settings sidebar** — because when the rail is *unpinned* (the old default) there is no on-screen affordance at all; you have to know to swipe in from a screen edge. Since Settings is the gateway to every feature (Voice, Screensaver, Doorbell, ESPHome), a user who never finds the edge-swipe never finds *any* feature.

## What

- **Pin the sidebar by default.** `SidebarSettingsDefaults.pinned` flips `false → true`, so a fresh install boots with the rail visible (the unpin button lives right in the rail).
- **Add a persistent "edge handle" setting (default on).** When the sidebar is unpinned *and* closed, a small tappable tab is drawn on the sidebar's edge that opens the rail — so an unpinned sidebar is never a dead end. Toggle it off in Settings for a clean, swipe-only edge. Threaded through the settings model → repository → both ViewModels → both UI states → a Settings toggle → `SidebarRailLayout`, mirroring the existing `showLabels` plumbing.
- **Refresh the README feature list** into 6 benefit-led bullets (and advertise the sidebar people were missing).

### Handle states

| Pinned | Edge handle | Result |
|--------|-------------|--------|
| true   | (n/a)       | Full rail always visible |
| false  | on          | Small tab on the edge; tap or swipe opens the rail |
| false  | off         | Clean edge; swipe-only (previous behaviour) |

## Notes

- **No migration, intentional.** `sidebar.pinned` is only stored once a user toggles pin, so the flipped default also reaches existing installs that never touched the setting (they become pinned on update); anyone who explicitly unpinned keeps their choice. Chosen deliberately over a new-installs-only first-run write.
- The edge-handle tab's tappable area is 48dp (meets the touch-target guideline); the visible bar stays a subtle 6dp and respects the sidebar `position` (left/right/top/bottom).

## Testing

- New/updated unit tests: default flip, `edgeHandle` persistence + delegation, propagation through both ViewModels. Full `:packages:app:testDebugUnitTest` passes.
- 4 new instrumented `SidebarRailTest` cases cover the handle gating (on→shown, off→hidden, pinned→hidden, tap→onOpen). **These were not executed** in this environment (no emulator) — they compile; please let CI run them on-device.
- Design/plan docs included under `docs/superpowers/`.

https://claude.ai/code/session_01WAF8dCqKXzhTDjpJayYt87
