### PR TITLE
feat: lower minSdk to 28 (Android 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ This is for installing a released build on a tablet. To build it yourself, see
 
 ### Requirements
 
-- **Android 11 or newer (API level 30). This is a hard requirement. The app
-  will not install on older Android versions.**
+- **Android 9 or newer (API level 28). This is a hard requirement. The app
+  will not install on older Android versions.** Old tablets also need a
+  reasonably recent WebView for the Home Assistant dashboard.
 - An arm64 (64-bit) tablet. The APK ships arm64-v8a only.
 - A running Home Assistant instance reachable from the tablet's network.
 

--- a/packages/app/build.gradle.kts
+++ b/packages/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId = "com.superdash"
-        minSdk = 30
+        minSdk = 28
         targetSdk = 35
         versionName = "0.2.0" // x-release-please-version
         // Derived so release-please only manages versionName. Monotonic

--- a/packages/app/src/main/kotlin/com/superdash/voice/VoiceService.kt
+++ b/packages/app/src/main/kotlin/com/superdash/voice/VoiceService.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.superdash.R
@@ -34,7 +35,8 @@ class VoiceService : LifecycleService() {
         ensureChannel()
         val foregroundStarted =
             VoiceServiceStartPolicy.tryStartForeground {
-                startForeground(
+                ServiceCompat.startForeground(
+                    this,
                     NOTIFICATION_ID,
                     buildNotification(),
                     ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,


### PR DESCRIPTION
## What / why

Lowers the app's floor from Android 11 (API 30) to Android 9 (API 28) so older wall-panel tablets can run superdash.

- `minSdk = 28` in `packages/app` (library modules already build at 26).
- The one API-30-era call site: `VoiceService` now uses `ServiceCompat.startForeground`, which falls back to the two-arg overload below API 29.
- README requirement updated, with a note that old tablets need a reasonably recent WebView for the HA dashboard.

Lint's `NewApi` check at minSdk 28 is clean; the Moonshine AAR keeps its existing `tools:overrideLibrary` (ELF-verified to only use pre-API-21 symbols).

## Testing done

- `./gradlew :packages:app:lintDebug ktlintCheck :packages:app:testDebugUnitTest :packages:app:assembleDebug` all pass.
- Smoke test on an API 28 arm64 emulator (google_apis image): app installs, launches, `KioskService` runs as a foreground service, no fatals in logcat across two cold starts.
- Not covered: full voice pipeline on API 28 (needs a configured HA instance + models); the changed call is androidx `ServiceCompat`'s standard pre-29 fallback.

## Checklist

- [x] `./gradlew ktlintCheck` passes
- [x] Tests pass (`./gradlew test`)
- [x] Follows the conventions in [AGENTS.md](../AGENTS.md)

https://claude.ai/code/session_01VtcsF847qobVofjtatHv7h