### PR TITLE
test: fix androidTest dexing at minSdk 28 (spaced method name)

### DIFF
--- a/packages/app/src/androidTest/kotlin/com/superdash/settings/LanguageSwitchTest.kt
+++ b/packages/app/src/androidTest/kotlin/com/superdash/settings/LanguageSwitchTest.kt
@@ -20,7 +20,7 @@ class LanguageSwitchTest {
     }
 
     @Test
-    fun `voice title differs between en and nl`() {
+    fun voiceTitleDiffersBetweenEnAndNl() {
         assertNotEquals(
             stringIn("en", R.string.settings_voice_title),
             stringIn("nl", R.string.settings_voice_title),


### PR DESCRIPTION
## Problem

Instrumented (`androidTest`) tests currently **cannot build on `main`**. Since `minSdk` dropped to 28 (#41), R8/D8 dexes to a DEX format older than v040, which forbids **spaces in method names**. `LanguageSwitchTest` used a Kotlin backtick method name with spaces (`` `voice title differs between en and nl` ``), so `dexBuilderDebugAndroidTest` fails — and because the whole `androidTest` APK dexes as one unit, that blocks *every* instrumented test from building or running.

**Why CI didn't catch it:** the "Lint, test and build" job runs `testDebugUnitTest` (JVM — no dexing) and assembles the *app* debug/release APKs. Nothing in CI dexes the *androidTest* APK, so this slipped through.

## Fix

Rename the one offending method to camelCase (`voiceTitleDiffersBetweenEnAndNl`) — the convention `SidebarRailTest` already uses. One-line change; behavior identical.

## Verification

Built and ran the instrumented suite on a physical tablet (Galaxy Tab A9, API-level device) — the `androidTest` APK now dexes and executes. `ktlintCheck` passes.

## Follow-up (not in this PR)

Running the suite for the first time surfaced **2 pre-existing failures** in `SidebarRailTest` (`openUnpinnedSidebarExposesDismissAction`, `openUnpinnedSidebarHidesBackgroundSemantics`) — assertions about the open-sidebar dismiss scrim / `hideFromAccessibility()` that had never actually executed and don't hold on-device. They're unrelated to this dex fix and to the recently-merged sidebar feature (whose own tests pass). Worth a separate change; also worth considering adding a CI job that actually dexes/runs (or at least assembles) the androidTest APK so this class of breakage is caught.

https://claude.ai/code/session_01WAF8dCqKXzhTDjpJayYt87
