### PR TITLE
fix(a11y): truly clear background semantics behind open modal sidebar

### DIFF
--- a/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
+++ b/packages/app/src/main/kotlin/com/superdash/kiosk/ui/SidebarRail.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -101,7 +100,7 @@ fun SidebarRailLayout(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .hideFromAccessibilityWhen(hideBackgroundSemantics),
+                        .clearSemanticsWhen(hideBackgroundSemantics),
             ) {
                 content()
             }
@@ -110,7 +109,7 @@ fun SidebarRailLayout(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .hideFromAccessibilityWhen(hideBackgroundSemantics),
+                    .clearSemanticsWhen(hideBackgroundSemantics),
         ) {
             overlays()
         }
@@ -155,9 +154,9 @@ fun SidebarRailLayout(
     }
 }
 
-private fun Modifier.hideFromAccessibilityWhen(value: Boolean): Modifier =
+private fun Modifier.clearSemanticsWhen(value: Boolean): Modifier =
     if (value) {
-        semantics { hideFromAccessibility() }
+        clearAndSetSemantics {}
     } else {
         this
     }


### PR DESCRIPTION
## Problem

While the **unpinned** sidebar is open, `SidebarRailLayout` tries to make the background + overlays inert to accessibility via a helper applying `Modifier.semantics { hideFromAccessibility() }`. A semantics-tree dump on a physical tablet proved that flag only lands on the empty wrapper `Box` and **does not cascade** — the background's `Text`/clickable nodes stay fully present in the semantics **and** accessibility tree. So TalkBack could still reach content behind the open modal sidebar, and the test `openUnpinnedSidebarHidesBackgroundSemantics` never actually passed (it had never run — instrumented tests weren't dexing until the minSdk-28 dex fix).

## Fix

Use `clearAndSetSemantics {}` instead, which truly strips the wrapper's whole subtree from both the semantics tree and the accessibility tree. Renamed the helper `hideFromAccessibilityWhen` → `clearSemanticsWhen` (the old name became misleading) and removed the now-unused `hideFromAccessibility` import.

**Touch behavior is unchanged** — the dismiss scrim `Box` (drawn on top, `fillMaxSize`) still intercepts taps for sighted/touch users. Only the accessibility layer changes: the background is now fully modal-inert while the sidebar is open, which is the intended behavior. When the sidebar closes (`value = false`), the helper returns `this` untouched, so nothing changes in the non-modal state.

## Verification

On a physical tablet: `connectedDebugAndroidTest` for `SidebarRailTest` → **12 tests, 0 failed**, including `openUnpinnedSidebarHidesBackgroundSemantics` (now passing) and the two `KeepsBackgroundSemantics` guards (pinned + closed-unpinned) which stay green. `ktlintCheck` + `assembleDebug` clean on the host.

## Note

Based on the dex-fix branch (#44) since these tests only build/run with that fix; GitHub will retarget to `main` once #44 merges.

https://claude.ai/code/session_01WAF8dCqKXzhTDjpJayYt87
