### PR TITLE
ci: dex the androidTest APK to guard minSdk breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
       # whisper.cpp is optional: CMake builds a stub when it is absent,
       # so CI does not need to fetch it.
       - name: Lint, test and build
-        run: ./gradlew ktlintCheck testDebugUnitTest :packages:app:assembleDebug :packages:app:assembleRelease
+        run: ./gradlew ktlintCheck testDebugUnitTest :packages:app:assembleDebug :packages:app:assembleRelease :packages:app:assembleDebugAndroidTest


### PR DESCRIPTION
## Problem

The CI "Lint, test and build" job runs `ktlintCheck testDebugUnitTest :packages:app:assembleDebug :packages:app:assembleRelease`. None of those compile or **dex** the `androidTest` APK. So when the instrumented test source recently became undexable (a Kotlin test method name with spaces stopped dexing after minSdk dropped to 28), CI stayed green while every instrumented test was silently unbuildable.

## Fix

Append `:packages:app:assembleDebugAndroidTest` to the gradle invocation. It compiles **and dexes** the androidTest APK on the existing `ubuntu-latest` runner — no device/emulator, ~seconds on an already-warm build — which is exactly the step that would have caught the breakage.

```diff
-        run: ./gradlew ktlintCheck testDebugUnitTest :packages:app:assembleDebug :packages:app:assembleRelease
+        run: ./gradlew ktlintCheck testDebugUnitTest :packages:app:assembleDebug :packages:app:assembleRelease :packages:app:assembleDebugAndroidTest
```

## Not included (deliberate)

A full emulator job that *runs* the instrumented suite would also catch runtime regressions, but it adds 5–10 min per run and would be intermittently red given known `SettingsContentTest` geometry flakiness. If runtime coverage is wanted later, add it as a separate **non-blocking** (nightly / `workflow_dispatch`) job rather than gating PRs. This PR only closes the "does the test APK compile+dex" gap, at near-zero cost and zero flakiness.

## Verification

`./gradlew :packages:app:assembleDebugAndroidTest` → BUILD SUCCESSFUL on the host. This PR's own CI run exercises the new step end-to-end.

## Note

Based on the dex-fix branch (#44) — the new step only passes with that fix present; GitHub will retarget to `main` once #44 merges.

https://claude.ai/code/session_01WAF8dCqKXzhTDjpJayYt87
