### PR TITLE
fix(immich): load album assets via search/metadata for Immich v3

### DIFF
--- a/packages/immich-client/src/main/kotlin/com/superdash/immich/ImmichApiClient.kt
+++ b/packages/immich-client/src/main/kotlin/com/superdash/immich/ImmichApiClient.kt
@@ -13,8 +13,10 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import kotlinx.coroutines.delay
+import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 
 private val log = Log("ImmichApi")
 
@@ -27,23 +29,26 @@ class ImmichApiClient(
     private val baseUrl: String = serverUrl.trimEnd('/')
 
     /** Paginate Immich search/metadata to build a slim catalog of every asset
-     *  the slideshow can show. When [albumId] is non-null, fetches that album's
-     *  assets directly (no pagination). Otherwise performs a single paginated
-     *  pass with no `type` filter — Immich returns IMAGE + VIDEO + AUDIO + OTHER
-     *  in one mixed stream — and filters AUDIO/OTHER out client-side. */
-    suspend fun listCatalog(albumId: String? = null): List<ImmichCatalogEntry> {
-        val assets = if (albumId != null) getAlbumAssets(albumId) else paginate()
-        return assets
+     *  the slideshow can show. When [albumId] is non-null, the same paginated pass
+     *  carries an `albumIds` filter so the server returns only that album's assets;
+     *  otherwise it returns the whole library. Either way there is no `type` filter —
+     *  Immich returns IMAGE + VIDEO + AUDIO + OTHER in one mixed stream — and
+     *  AUDIO/OTHER are filtered out client-side.
+     *
+     *  Album assets go through search/metadata (not `GET /api/albums/{id}`) because
+     *  Immich v3 dropped the inline `assets` array from the album-details response;
+     *  the `albumIds` search filter works on both v2 and v3. */
+    suspend fun listCatalog(albumId: String? = null): List<ImmichCatalogEntry> =
+        paginate(albumId)
             .filter { it.type == IMMICH_IMAGE || it.type == IMMICH_VIDEO }
             .map { it.toCatalogEntry() }
-    }
 
-    private suspend fun paginate(): List<ImmichAsset> {
+    private suspend fun paginate(albumId: String? = null): List<ImmichAsset> {
         val out = mutableListOf<ImmichAsset>()
         var page: String? = "1"
         var pagesFetched = 0
         while (page != null) {
-            val response = fetchPageWithRetry(page) ?: break
+            val response = fetchPageWithRetry(page, albumId) ?: break
             out += response.assets.items
             pagesFetched++
             // Guard against a misbehaving server that returns a non-null nextPage
@@ -58,11 +63,14 @@ class ImmichApiClient(
         return out
     }
 
-    private suspend fun fetchPageWithRetry(page: String): ImmichSearchPage? {
+    private suspend fun fetchPageWithRetry(
+        page: String,
+        albumId: String?,
+    ): ImmichSearchPage? {
         var lastError: Exception? = null
         repeat(CATALOG_PAGE_ATTEMPTS) { attempt ->
             try {
-                return fetchSearchPage(page)
+                return fetchSearchPage(page, albumId)
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -76,7 +84,10 @@ class ImmichApiClient(
         return null
     }
 
-    private suspend fun fetchSearchPage(page: String): ImmichSearchPage {
+    private suspend fun fetchSearchPage(
+        page: String,
+        albumId: String?,
+    ): ImmichSearchPage {
         val response: HttpResponse =
             httpClient.post {
                 url("$baseUrl/api/search/metadata")
@@ -87,6 +98,9 @@ class ImmichApiClient(
                         put("page", page.toInt())
                         put("size", 1000)
                         put("withExif", true)
+                        if (albumId != null) {
+                            putJsonArray("albumIds") { add(albumId) }
+                        }
                     },
                 )
             }
@@ -104,9 +118,6 @@ class ImmichApiClient(
 
     suspend fun getAlbumByName(name: String): ImmichAlbum? =
         listAlbums().find { it.albumName.equals(name, ignoreCase = true) }
-
-    suspend fun getAlbumAssets(albumId: String): List<ImmichAsset> =
-        authGet("/api/albums/$albumId").body<ImmichAlbumDetails>().assets
 
     /** Builds the thumbnail URL. Auth is supplied via the `x-api-key` header at
      *  request time by the Coil OkHttp interceptor (see SuperdashApp), not via a
@@ -152,10 +163,13 @@ class ImmichApiClient(
     }
 
     /** Probes whether the API key has `asset.view` by HEAD-ing one asset's
-     *  thumbnail. Returns null if the album has no assets. */
+     *  thumbnail. Returns null if the album has no assets. Resolves the first
+     *  asset via the same albumIds-filtered search the catalog uses, so it stays
+     *  correct on Immich v3 (which no longer inlines assets in album details). */
     suspend fun canViewAsset(albumId: String): Boolean? {
         val firstAsset =
-            runCatching { getAlbumAssets(albumId).firstOrNull()?.id }.getOrNull()
+            runCatching { fetchSearchPage(page = "1", albumId = albumId).assets.items.firstOrNull()?.id }
+                .getOrNull()
                 ?: return null
         return runCatching { authHead("/api/assets/$firstAsset/thumbnail?size=preview").status.value in 200..299 }
             .getOrElse { false }

--- a/packages/immich-client/src/main/kotlin/com/superdash/immich/ImmichApiClient.kt
+++ b/packages/immich-client/src/main/kotlin/com/superdash/immich/ImmichApiClient.kt
@@ -37,13 +37,18 @@ class ImmichApiClient(
      *
      *  Album assets go through search/metadata (not `GET /api/albums/{id}`) because
      *  Immich v3 dropped the inline `assets` array from the album-details response;
-     *  the `albumIds` search filter works on both v2 and v3. */
+     *  the `albumIds` search filter works on both v2 and v3.
+     *
+     *  Caveat vs the old album-details payload: search/metadata scopes results to
+     *  the authenticated user (plus partners) and omits archived assets, so a
+     *  shared album containing another user's uploads — or archived photos — can
+     *  return a subset of what `GET /api/albums/{id}` used to. */
     suspend fun listCatalog(albumId: String? = null): List<ImmichCatalogEntry> =
         paginate(albumId)
             .filter { it.type == IMMICH_IMAGE || it.type == IMMICH_VIDEO }
             .map { it.toCatalogEntry() }
 
-    private suspend fun paginate(albumId: String? = null): List<ImmichAsset> {
+    private suspend fun paginate(albumId: String?): List<ImmichAsset> {
         val out = mutableListOf<ImmichAsset>()
         var page: String? = "1"
         var pagesFetched = 0
@@ -87,6 +92,8 @@ class ImmichApiClient(
     private suspend fun fetchSearchPage(
         page: String,
         albumId: String?,
+        size: Int = CATALOG_PAGE_SIZE,
+        withExif: Boolean = true,
     ): ImmichSearchPage {
         val response: HttpResponse =
             httpClient.post {
@@ -96,8 +103,8 @@ class ImmichApiClient(
                 setBody(
                     buildJsonObject {
                         put("page", page.toInt())
-                        put("size", 1000)
-                        put("withExif", true)
+                        put("size", size)
+                        put("withExif", withExif)
                         if (albumId != null) {
                             putJsonArray("albumIds") { add(albumId) }
                         }
@@ -168,8 +175,12 @@ class ImmichApiClient(
      *  correct on Immich v3 (which no longer inlines assets in album details). */
     suspend fun canViewAsset(albumId: String): Boolean? {
         val firstAsset =
-            runCatching { fetchSearchPage(page = "1", albumId = albumId).assets.items.firstOrNull()?.id }
-                .getOrNull()
+            runCatching {
+                fetchSearchPage(page = "1", albumId = albumId, size = 1, withExif = false)
+                    .assets.items
+                    .firstOrNull()
+                    ?.id
+            }.getOrNull()
                 ?: return null
         return runCatching { authHead("/api/assets/$firstAsset/thumbnail?size=preview").status.value in 200..299 }
             .getOrElse { false }
@@ -190,6 +201,7 @@ class ImmichApiClient(
     private companion object {
         const val IMMICH_IMAGE = "IMAGE"
         const val IMMICH_VIDEO = "VIDEO"
+        const val CATALOG_PAGE_SIZE = 1000
         const val CATALOG_PAGE_ATTEMPTS = 3
         const val CATALOG_PAGE_RETRY_DELAY_MS = 1_000L
 

--- a/packages/immich-client/src/main/kotlin/com/superdash/immich/ImmichModels.kt
+++ b/packages/immich-client/src/main/kotlin/com/superdash/immich/ImmichModels.kt
@@ -84,13 +84,6 @@ data class ImmichAlbum(
 )
 
 @Serializable
-data class ImmichAlbumDetails(
-    val id: String,
-    val albumName: String,
-    val assets: List<ImmichAsset> = emptyList(),
-)
-
-@Serializable
 data class ImmichPingResponse(
     val res: String,
 )

--- a/packages/immich-client/src/test/kotlin/com/superdash/immich/ImmichApiClientTest.kt
+++ b/packages/immich-client/src/test/kotlin/com/superdash/immich/ImmichApiClientTest.kt
@@ -199,32 +199,45 @@ class ImmichApiClientTest {
         }
 
     @Test
-    fun `listCatalog for album returns every asset without pagination`() =
+    fun `listCatalog for album fetches via search-metadata with albumIds filter and paginates`() =
         runTest {
+            // Immich v3 dropped the inline assets array from GET /api/albums/{id}, so the album
+            // fetch goes through POST /api/search/metadata with an albumIds filter — the same
+            // paginated path used for the whole library, and one that works on both v2 and v3.
+            val responses =
+                listOf(
+                    """{"assets":{"items":[{"id":"a","type":"IMAGE","originalFileName":"a.jpg","fileCreatedAt":"1970-01-01T00:00:00Z"},{"id":"b","type":"VIDEO","originalFileName":"b.mp4","fileCreatedAt":"1970-01-01T00:00:00Z"}],"nextPage":"2"}}""",
+                    """{"assets":{"items":[{"id":"c","type":"IMAGE","originalFileName":"c.jpg","fileCreatedAt":"1970-01-01T00:00:00Z"}],"nextPage":null}}""",
+                )
+            var pageIndex = 0
+            val capturedPaths = mutableListOf<String>()
+            val capturedBodies = mutableListOf<String>()
             val engine =
                 MockEngine { request ->
-                    val path = request.url.encodedPath
-                    val body =
-                        if (path == "/api/albums/alb-1") {
-                            """{"id":"alb-1","albumName":"X","assets":[
-                    {"id":"a","type":"IMAGE","originalFileName":"a.jpg","fileCreatedAt":"1970-01-01T00:00:00Z"},
-                    {"id":"b","type":"VIDEO","originalFileName":"b.mp4","fileCreatedAt":"1970-01-01T00:00:00Z"}
-                ]}"""
-                        } else {
-                            "[]"
-                        }
-                    respond(content = body, headers = headersOf("Content-Type", ContentType.Application.Json.toString()))
+                    capturedPaths += request.url.encodedPath
+                    capturedBodies += request.body.toByteArray().decodeToString()
+                    respond(
+                        content = responses[pageIndex++],
+                        headers = headersOf("Content-Type", ContentType.Application.Json.toString()),
+                    )
                 }
             val client =
                 ImmichApiClient(
                     HttpClient(engine) { install(ContentNegotiation) { json() } },
                     "http://immich",
                     "key",
+                    sleep = {},
                 )
 
             val catalog = client.listCatalog(albumId = "alb-1")
 
-            assertEquals(listOf("a", "b"), catalog.map { it.id })
+            assertEquals(listOf("a", "b", "c"), catalog.map { it.id })
+            assertEquals(2, pageIndex)
+            capturedPaths.forEach { assertEquals("/api/search/metadata", it) }
+            capturedBodies.forEach { body ->
+                assertTrue("album request must carry albumIds filter: $body", body.contains("\"albumIds\""))
+                assertTrue("album request must reference the album id: $body", body.contains("alb-1"))
+            }
         }
 
     @Test
@@ -260,6 +273,11 @@ class ImmichApiClientTest {
             assertFalse(
                 "request body must not contain \"type\" field: ${capturedBodies[0]}",
                 capturedBodies[0].contains("\"type\""),
+            )
+            // Whole-library pass must not carry an album filter.
+            assertFalse(
+                "whole-library request must not contain albumIds: ${capturedBodies[0]}",
+                capturedBodies[0].contains("albumIds"),
             )
         }
 

--- a/packages/immich-client/src/test/kotlin/com/superdash/immich/ImmichApiClientTest.kt
+++ b/packages/immich-client/src/test/kotlin/com/superdash/immich/ImmichApiClientTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -235,8 +236,7 @@ class ImmichApiClientTest {
             assertEquals(2, pageIndex)
             capturedPaths.forEach { assertEquals("/api/search/metadata", it) }
             capturedBodies.forEach { body ->
-                assertTrue("album request must carry albumIds filter: $body", body.contains("\"albumIds\""))
-                assertTrue("album request must reference the album id: $body", body.contains("alb-1"))
+                assertTrue("album request must carry exact albumIds filter: $body", body.contains("\"albumIds\":[\"alb-1\"]"))
             }
         }
 
@@ -302,6 +302,69 @@ class ImmichApiClientTest {
             val asset = client.getAsset("some-id")
             assertEquals("name.jpg", asset.originalFileName)
             assertEquals("Paris", asset.exifInfo?.city)
+        }
+
+    @Test
+    fun `canViewAsset returns null when the album has no assets`() =
+        runTest {
+            val engine =
+                MockEngine {
+                    respond(
+                        content = """{"assets":{"items":[],"nextPage":null}}""",
+                        headers = headersOf("Content-Type", ContentType.Application.Json.toString()),
+                    )
+                }
+            val client =
+                ImmichApiClient(HttpClient(engine) { install(ContentNegotiation) { json() } }, "http://immich", "key")
+
+            assertNull(client.canViewAsset("alb-1"))
+        }
+
+    @Test
+    fun `canViewAsset returns true on a 2xx thumbnail HEAD and probes one asset via albumIds`() =
+        runTest {
+            var searchBody = ""
+            val engine =
+                MockEngine { request ->
+                    if (request.url.encodedPath == "/api/search/metadata") {
+                        searchBody = request.body.toByteArray().decodeToString()
+                        respond(
+                            content = """{"assets":{"items":[{"id":"a","type":"IMAGE","originalFileName":"a.jpg","fileCreatedAt":"1970-01-01T00:00:00Z"}],"nextPage":null}}""",
+                            headers = headersOf("Content-Type", ContentType.Application.Json.toString()),
+                        )
+                    } else {
+                        // thumbnail HEAD
+                        respond("", status = HttpStatusCode.OK)
+                    }
+                }
+            val client =
+                ImmichApiClient(HttpClient(engine) { install(ContentNegotiation) { json() } }, "http://immich", "key")
+
+            assertEquals(true, client.canViewAsset("alb-1"))
+            // The probe filters to the album and fetches a single asset without EXIF.
+            assertTrue("probe must filter by album: $searchBody", searchBody.contains("\"albumIds\":[\"alb-1\"]"))
+            assertTrue("probe must request a single asset: $searchBody", searchBody.contains("\"size\":1"))
+            assertFalse("probe must not request EXIF: $searchBody", searchBody.contains("\"withExif\":true"))
+        }
+
+    @Test
+    fun `canViewAsset returns false when the thumbnail HEAD is forbidden`() =
+        runTest {
+            val engine =
+                MockEngine { request ->
+                    if (request.url.encodedPath == "/api/search/metadata") {
+                        respond(
+                            content = """{"assets":{"items":[{"id":"a","type":"IMAGE","originalFileName":"a.jpg","fileCreatedAt":"1970-01-01T00:00:00Z"}],"nextPage":null}}""",
+                            headers = headersOf("Content-Type", ContentType.Application.Json.toString()),
+                        )
+                    } else {
+                        respond("forbidden", status = HttpStatusCode.Forbidden)
+                    }
+                }
+            val client =
+                ImmichApiClient(HttpClient(engine) { install(ContentNegotiation) { json() } }, "http://immich", "key")
+
+            assertEquals(false, client.canViewAsset("alb-1"))
         }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/packages/screensaver/src/test/kotlin/com/superdash/screensaver/slideshow/ImmichSlideshowSourceTest.kt
+++ b/packages/screensaver/src/test/kotlin/com/superdash/screensaver/slideshow/ImmichSlideshowSourceTest.kt
@@ -86,24 +86,6 @@ class ImmichSlideshowSourceTest {
                             headers = headersOf("Content-Type", "application/json"),
                         )
                     }
-                    path.startsWith("/api/albums/") -> {
-                        val albumId = path.removePrefix("/api/albums/")
-                        if (albumId == mockAlbumId) {
-                            respond(
-                                content =
-                                    Json.encodeToString(
-                                        com.superdash.immich.ImmichAlbumDetails(
-                                            id = mockAlbumId,
-                                            albumName = mockAlbumName,
-                                            assets = assets,
-                                        ),
-                                    ),
-                                headers = headersOf("Content-Type", "application/json"),
-                            )
-                        } else {
-                            respond("[]", headers = headersOf("Content-Type", "application/json"))
-                        }
-                    }
                     path.startsWith("/api/assets/") && !path.contains("/thumbnail") && !path.contains("/video") -> {
                         val id = path.removePrefix("/api/assets/")
                         val asset = byId[id]
@@ -555,15 +537,11 @@ class ImmichSlideshowSourceTest {
                                 content = Json.encodeToString(listOf(ImmichAlbum(id = mockAlbumId, albumName = "TEST"))),
                                 headers = headersOf("Content-Type", "application/json"),
                             )
-                        path.startsWith("/api/albums/") ->
+                        path == "/api/search/metadata" ->
                             respond(
                                 content =
                                     Json.encodeToString(
-                                        com.superdash.immich.ImmichAlbumDetails(
-                                            id = mockAlbumId,
-                                            albumName = "TEST",
-                                            assets = listOf(asset("a")),
-                                        ),
+                                        ImmichSearchPage(ImmichSearchAssetsBucket(items = listOf(asset("a")), nextPage = null)),
                                     ),
                                 headers = headersOf("Content-Type", "application/json"),
                             )
@@ -705,16 +683,12 @@ class ImmichSlideshowSourceTest {
                                 content = Json.encodeToString(listOf(ImmichAlbum(id = mockAlbumId, albumName = mockAlbumName))),
                                 headers = headersOf("Content-Type", "application/json"),
                             )
-                        path.startsWith("/api/albums/") -> {
+                        path == "/api/search/metadata" -> {
                             fetchCount++
                             respond(
                                 content =
                                     Json.encodeToString(
-                                        com.superdash.immich.ImmichAlbumDetails(
-                                            id = mockAlbumId,
-                                            albumName = mockAlbumName,
-                                            assets = listOf(asset("a")),
-                                        ),
+                                        ImmichSearchPage(ImmichSearchAssetsBucket(items = listOf(asset("a")), nextPage = null)),
                                     ),
                                 headers = headersOf("Content-Type", "application/json"),
                             )
@@ -774,15 +748,11 @@ class ImmichSlideshowSourceTest {
                                 content = Json.encodeToString(listOf(ImmichAlbum(id = mockAlbumId, albumName = mockAlbumName))),
                                 headers = headersOf("Content-Type", "application/json"),
                             )
-                        path.startsWith("/api/albums/") ->
+                        path == "/api/search/metadata" ->
                             respond(
                                 content =
                                     Json.encodeToString(
-                                        com.superdash.immich.ImmichAlbumDetails(
-                                            id = mockAlbumId,
-                                            albumName = mockAlbumName,
-                                            assets = items,
-                                        ),
+                                        ImmichSearchPage(ImmichSearchAssetsBucket(items = items, nextPage = null)),
                                     ),
                                 headers = headersOf("Content-Type", "application/json"),
                             )


### PR DESCRIPTION
Immich v3 removed the inline `assets` array from `GET /api/albums/{id}`
(AlbumResponseDto now exposes only `assetCount`), so album-scoped slideshows
silently returned an empty catalog and the screensaver went black — while
whole-library mode (`POST /api/search/metadata`) kept working.

Fetch album assets through the same paginated `search/metadata` pass with an
`albumIds` filter, which exists on both Immich v2 and v3, unifying the album
and whole-library paths. Drop the now-dead `getAlbumAssets` / `ImmichAlbumDetails`.

Also from review follow-up:
- Narrow the `canViewAsset` probe (`size=1`, no EXIF) and add test coverage.
- Document that `search/metadata` scopes to the authenticated user and omits
  archived assets (a behavioral delta vs the old album-details payload).

Verified live against an Immich 3.0.1 server: album "Tablet" loads its 12
assets and renders in the screensaver.
