### PR TITLE
fix(camera): recover capture when the camera permission is granted, and quiet ESPHome disconnects

### DIFF
--- a/docs/architecture/ha-integration.md
+++ b/docs/architecture/ha-integration.md
@@ -86,6 +86,8 @@ The camera module exposes:
 - `motion_sensitivity` and `motion_clear_delay_sec` numbers to tune detection and event hold.
 - `camera_status` text sensor reporting the pipeline state (`Off`, `Running`, `PermissionMissing`, `Error`).
 
+If the camera is enabled but Android's camera permission is not granted (for example after a reinstall, or after enabling it remotely over ESPHome), the `camera_status` sensor reports `PermissionMissing` and the tablet's Settings screen shows a "Camera permission required — tap to grant" row; granting it restarts capture automatically.
+
 The JPEG stream is chunked to 15 KiB frames to fit under the 16 KiB Noise frame cap. A rolling ~5 second window is refreshed at several fps; Home Assistant polls the picture entity to fetch the latest frame.
 
 Enabling the camera also starts a `camera`-type foreground service so capture keeps running while the tablet screen is off. Android blocks starting a foreground service from the background, so if the camera is enabled over ESPHome while the tablet is asleep the stream does not come up immediately — it starts automatically the next time the tablet's screen turns on.

--- a/packages/app/src/main/kotlin/com/superdash/AppGraph.kt
+++ b/packages/app/src/main/kotlin/com/superdash/AppGraph.kt
@@ -231,6 +231,16 @@ class AppGraph(
             stop = { CameraService.stop(application.applicationContext) },
         )
 
+    /** Re-attempt camera capture after the CAMERA permission is granted while
+     *  the camera is already enabled. Starts the camera foreground service
+     *  (its own permission check now passes) and forces the pipeline to re-run
+     *  its start. Safe to call when already running (idempotent FGS start +
+     *  a brief pipeline re-bind). */
+    fun restartCameraCapture() {
+        CameraService.start(application.applicationContext)
+        cameraController.requestRestart()
+    }
+
     val haConnectivityController: HaConnectivityController =
         HaConnectivityController(
             context = application,

--- a/packages/app/src/main/kotlin/com/superdash/MainActivity.kt
+++ b/packages/app/src/main/kotlin/com/superdash/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.superdash
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.GestureDetector
 import android.view.KeyEvent
@@ -20,11 +22,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.superdash.camera.CameraAvailability
 import com.superdash.core.log.Log
 import com.superdash.ha.HaOAuthInterceptor
 import com.superdash.ha.JsBridge
@@ -187,6 +191,16 @@ class MainActivity : AppCompatActivity() {
         val launchedFromBoot = intent.getBooleanExtra(BootLauncher.EXTRA_LAUNCHED_FROM_BOOT, false)
         lifecycleScope.launch {
             kioskWindow.apply(launchedFromBoot, graph.settings.snapshot())
+        }
+        // Recover camera capture if the user granted the CAMERA permission from the
+        // OS app-info screen and returned to the kiosk screen directly (not Settings).
+        val cameraGranted =
+            ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) ==
+                PackageManager.PERMISSION_GRANTED
+        if (cameraGranted &&
+            graph.cameraController.availability.value is CameraAvailability.PermissionMissing
+        ) {
+            graph.restartCameraCapture()
         }
     }
 

--- a/packages/app/src/main/kotlin/com/superdash/settings/SettingsActivity.kt
+++ b/packages/app/src/main/kotlin/com/superdash/settings/SettingsActivity.kt
@@ -23,6 +23,7 @@ import com.superdash.AppGraph
 import com.superdash.MainActivity
 import com.superdash.R
 import com.superdash.SuperdashApp
+import com.superdash.camera.CameraAvailability
 import com.superdash.core.locale.SupportedLanguage
 import com.superdash.core.util.UrlNormalizer
 import com.superdash.doorbell.DoorbellConfig
@@ -195,7 +196,10 @@ class SettingsActivity : AppCompatActivity() {
         registerForActivityResult(
             ActivityResultContracts.RequestPermission(),
         ) { granted ->
-            settingsViewModel.setCameraEnabled(granted)
+            if (granted) {
+                settingsViewModel.setCameraEnabled(true)
+            }
+            refreshCameraPermissionState()
         }
 
     fun requestCameraAndEnable() {
@@ -207,6 +211,26 @@ class SettingsActivity : AppCompatActivity() {
         } else {
             cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
         }
+    }
+
+    private fun refreshCameraPermissionState() {
+        val granted =
+            ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) ==
+                PackageManager.PERMISSION_GRANTED
+        settingsViewModel.setCameraPermissionGranted(granted)
+        if (granted) {
+            val graph = (application as SuperdashApp).graph
+            // Only nudge when capture wanted to run but could not (permission was
+            // missing); avoids a needless re-bind on every resume.
+            if (graph.cameraController.availability.value is CameraAvailability.PermissionMissing) {
+                graph.restartCameraCapture()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refreshCameraPermissionState()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/packages/app/src/main/kotlin/com/superdash/settings/SettingsUiState.kt
+++ b/packages/app/src/main/kotlin/com/superdash/settings/SettingsUiState.kt
@@ -181,6 +181,7 @@ data class CameraSettingsState(
     val motionSensitivity: Int,
     val wakeOnMotion: Boolean,
     val allowRemoteEnable: Boolean,
+    val cameraPermissionGranted: Boolean,
 ) {
     companion object {
         fun empty(): CameraSettingsState =
@@ -192,6 +193,7 @@ data class CameraSettingsState(
                 motionSensitivity = 50,
                 wakeOnMotion = false,
                 allowRemoteEnable = true,
+                cameraPermissionGranted = true,
             )
     }
 }

--- a/packages/app/src/main/kotlin/com/superdash/settings/SettingsViewModel.kt
+++ b/packages/app/src/main/kotlin/com/superdash/settings/SettingsViewModel.kt
@@ -211,6 +211,12 @@ class SettingsViewModel(
             )
         }
 
+    private val cameraPermissionGranted = MutableStateFlow(true)
+
+    fun setCameraPermissionGranted(granted: Boolean) {
+        cameraPermissionGranted.value = granted
+    }
+
     private val cameraUiStateFlow: Flow<CameraSettingsState> =
         combine(
             combine(
@@ -228,7 +234,8 @@ class SettingsViewModel(
             ) { motionSensitivity, wakeOnMotion, allowRemoteEnable ->
                 CameraTail(motionSensitivity, wakeOnMotion, allowRemoteEnable)
             },
-        ) { core, tail ->
+            cameraPermissionGranted,
+        ) { core, tail, permissionGranted ->
             CameraSettingsState(
                 enabled = core.enabled,
                 facing = core.facing,
@@ -237,6 +244,7 @@ class SettingsViewModel(
                 motionSensitivity = tail.motionSensitivity,
                 wakeOnMotion = tail.wakeOnMotion,
                 allowRemoteEnable = tail.allowRemoteEnable,
+                cameraPermissionGranted = permissionGranted,
             )
         }
 

--- a/packages/app/src/main/kotlin/com/superdash/settings/ui/CameraSettingsSection.kt
+++ b/packages/app/src/main/kotlin/com/superdash/settings/ui/CameraSettingsSection.kt
@@ -43,6 +43,13 @@ fun CameraSettingsSection(
             )
         },
     )
+    if (state.enabled && !state.cameraPermissionGranted) {
+        SettingsActionRow(
+            label = stringResource(R.string.settings_camera_permission_required_title),
+            supportingText = stringResource(R.string.settings_camera_permission_required_summary),
+            onClick = actions.onRequestCameraEnable,
+        )
+    }
     if (state.enabled) {
         SettingsChoiceRow(
             label = stringResource(R.string.settings_camera_facing_label),

--- a/packages/app/src/main/res/values-fr/strings.xml
+++ b/packages/app/src/main/res/values-fr/strings.xml
@@ -72,6 +72,8 @@
     <string name="settings_camera_wake_on_motion_summary">Quitter l\'écran de veille lorsqu\'un mouvement est détecté</string>
     <string name="settings_camera_allow_remote_enable_title">Activation à distance</string>
     <string name="settings_camera_allow_remote_enable_summary">Autoriser Home Assistant à activer la caméra. La désactivation à distance reste toujours possible.</string>
+    <string name="settings_camera_permission_required_title">Autorisation caméra requise</string>
+    <string name="settings_camera_permission_required_summary">La caméra est activée mais Android n\'a pas accordé l\'accès à la caméra. Appuyez pour autoriser.</string>
     <string name="settings_esphome_enabled_title">Activé</string>
     <string name="settings_esphome_enabled_summary">Exposer superdash à HA via le protocole ESPHome.</string>
     <string name="settings_esphome_encryption_key_title">Clé de chiffrement (base64)</string>

--- a/packages/app/src/main/res/values-nl/strings.xml
+++ b/packages/app/src/main/res/values-nl/strings.xml
@@ -72,6 +72,8 @@
     <string name="settings_camera_wake_on_motion_summary">Screensaver afsluiten wanneer beweging wordt gedetecteerd</string>
     <string name="settings_camera_allow_remote_enable_title">Op afstand inschakelen</string>
     <string name="settings_camera_allow_remote_enable_summary">Home Assistant toestaan de camera in te schakelen. Op afstand uitschakelen blijft altijd mogelijk.</string>
+    <string name="settings_camera_permission_required_title">Cameratoestemming vereist</string>
+    <string name="settings_camera_permission_required_summary">De camera is ingeschakeld maar Android heeft geen cameratoegang verleend. Tik om toe te staan.</string>
     <string name="settings_esphome_enabled_title">Ingeschakeld</string>
     <string name="settings_esphome_enabled_summary">Maak superdash via het ESPHome-protocol zichtbaar voor HA.</string>
     <string name="settings_esphome_encryption_key_title">Versleutelingssleutel (base64)</string>

--- a/packages/app/src/main/res/values/strings.xml
+++ b/packages/app/src/main/res/values/strings.xml
@@ -72,6 +72,8 @@
     <string name="settings_camera_wake_on_motion_summary">Exit the screensaver when motion is detected</string>
     <string name="settings_camera_allow_remote_enable_title">Allow remote enable</string>
     <string name="settings_camera_allow_remote_enable_summary">Let Home Assistant turn the camera on. Turning the camera off remotely is always allowed.</string>
+    <string name="settings_camera_permission_required_title">Camera permission required</string>
+    <string name="settings_camera_permission_required_summary">The camera is enabled but Android hasn\'t granted camera access. Tap to grant.</string>
 
     <string name="settings_esphome_enabled_title">Enabled</string>
     <string name="settings_esphome_enabled_summary">Expose superdash to HA via the ESPHome protocol.</string>

--- a/packages/app/src/test/kotlin/com/superdash/settings/SettingsViewModelTest.kt
+++ b/packages/app/src/test/kotlin/com/superdash/settings/SettingsViewModelTest.kt
@@ -634,6 +634,20 @@ class SettingsViewModelTest {
             assertEquals(false, camera.lastAllowRemoteEnable)
         }
 
+    @Test
+    fun `camera permission flag defaults granted and reflects setter`() =
+        runTest {
+            val camera = FakeCameraSettings()
+            val viewModel = buildViewModel(camera = camera)
+            backgroundScope.launch { viewModel.uiState.collect {} }
+            advanceUntilIdle()
+            assertEquals(true, viewModel.uiState.value.camera.cameraPermissionGranted)
+
+            viewModel.setCameraPermissionGranted(false)
+            advanceUntilIdle()
+            assertEquals(false, viewModel.uiState.value.camera.cameraPermissionGranted)
+        }
+
     private class FakeKioskSettings(
         keepScreenOnFlow: MutableStateFlow<Boolean> = MutableStateFlow(true),
         startOnBootFlow: MutableStateFlow<Boolean> = MutableStateFlow(true),

--- a/packages/camera/src/main/kotlin/com/superdash/camera/CameraController.kt
+++ b/packages/camera/src/main/kotlin/com/superdash/camera/CameraController.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -75,6 +76,9 @@ class CameraController(
      *  pipeline runs; encoding is skipped when nobody collects. */
     val jpegFrames: Flow<ByteArray> = jpegFramesFlow.asSharedFlow()
 
+    private val restartRequests =
+        MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
     private val clearDelaySec: StateFlow<Int> =
         settings.motionClearDelaySec.stateIn(scope, SharingStarted.Eagerly, 15)
 
@@ -87,21 +91,33 @@ class CameraController(
     suspend fun latestJpeg(): ByteArray? =
         latestFrame.value?.let { frame -> pipeline.encodeJpeg(frame, JPEG_QUALITY) }
 
+    /** Forces the pipeline to re-run its start with the current settings, even
+     *  though no setting changed. Used to recover capture after the CAMERA
+     *  permission is granted while the camera is already enabled — a same-value
+     *  settings write is filtered by distinctUntilChanged, so nothing else
+     *  re-attempts the start. No-op while the camera is disabled. */
+    fun requestRestart() {
+        restartRequests.tryEmit(Unit)
+    }
+
     private suspend fun runPipelineControl() {
-        combine(settings.enabled, settings.resolution, settings.facing) { enabled, resolution, facing ->
-            Triple(enabled, resolution, facing)
-        }.distinctUntilChanged().collect { (enabled, resolution, facing) ->
-            if (enabled) {
-                val (width, height) = parseResolution(resolution)
-                pipelineWanted = true
-                pipeline.start(CameraPipelineConfig(width, height, facingFront = facing != "back"))
-            } else {
-                pipelineWanted = false
-                pipeline.stop()
-                latestFrame.value = null
-                motionActiveState.value = false
+        val config =
+            combine(settings.enabled, settings.resolution, settings.facing) { enabled, resolution, facing ->
+                Triple(enabled, resolution, facing)
+            }.distinctUntilChanged()
+        combine(config, restartRequests.onStart { emit(Unit) }) { current, _ -> current }
+            .collect { (enabled, resolution, facing) ->
+                if (enabled) {
+                    val (width, height) = parseResolution(resolution)
+                    pipelineWanted = true
+                    pipeline.start(CameraPipelineConfig(width, height, facingFront = facing != "back"))
+                } else {
+                    pipelineWanted = false
+                    pipeline.stop()
+                    latestFrame.value = null
+                    motionActiveState.value = false
+                }
             }
-        }
     }
 
     private suspend fun cacheAndEncodeFrames() {

--- a/packages/camera/src/test/kotlin/com/superdash/camera/CameraControllerTest.kt
+++ b/packages/camera/src/test/kotlin/com/superdash/camera/CameraControllerTest.kt
@@ -23,6 +23,7 @@ private class FakePipeline : CameraPipeline {
     override val availability: StateFlow<CameraAvailability> = availabilityState.asStateFlow()
     var started: CameraPipelineConfig? = null
     var stopCount = 0
+    var startCount = 0
 
     /** Simulates [CameraXPipeline.stop] posting the unbind asynchronously: when
      *  true, [stop] leaves [availabilityState] at Running instead of flipping
@@ -32,6 +33,7 @@ private class FakePipeline : CameraPipeline {
 
     override fun start(config: CameraPipelineConfig) {
         started = config
+        startCount++
         availabilityState.value = CameraAvailability.Running
     }
 
@@ -410,5 +412,44 @@ class CameraControllerTest {
             now = 150L
             pipeline.framesFlow.emit(testFrame())
             assertEquals(2, received.size)
+        }
+
+    @Test
+    fun `requestRestart re-invokes pipeline start while enabled`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val pipeline = FakePipeline()
+            val settings = FakeSettings()
+            settings.enabledState.value = true
+            val controller =
+                CameraController(
+                    pipeline = pipeline,
+                    settings = settings,
+                    detectorFactories = emptyMap(),
+                    scope = backgroundScope,
+                    nowMs = { 0L },
+                )
+            val startsAfterEnable = pipeline.startCount
+            assertTrue(startsAfterEnable >= 1)
+
+            controller.requestRestart()
+
+            assertEquals(startsAfterEnable + 1, pipeline.startCount)
+        }
+
+    @Test
+    fun `requestRestart does nothing while disabled`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val pipeline = FakePipeline()
+            val settings = FakeSettings()
+            settings.enabledState.value = false
+            CameraController(
+                pipeline = pipeline,
+                settings = settings,
+                detectorFactories = emptyMap(),
+                scope = backgroundScope,
+                nowMs = { 0L },
+            ).requestRestart()
+
+            assertEquals(0, pipeline.startCount)
         }
 }

--- a/packages/esphome-server/src/main/kotlin/com/superdash/esphome/EsphomeConnection.kt
+++ b/packages/esphome-server/src/main/kotlin/com/superdash/esphome/EsphomeConnection.kt
@@ -49,6 +49,38 @@ internal const val DEFAULT_IDLE_TIMEOUT_MS = 90_000L
  *  refreshes the window with repeated stream requests while a client watches. */
 internal const val CAMERA_STREAM_WINDOW_NANOS = 5_000_000_000L
 
+/** True when [throwable] (or any cause in its chain) is a normal client
+ *  disconnect — a closed channel, an EOF, or an IOException whose message
+ *  indicates a broken pipe / connection reset / closed socket. HA closing a
+ *  camera live-view surfaces this way (as a broken-pipe IOException rethrown
+ *  from the frame-writer child coroutine); it is not a fault worth a stack
+ *  trace. `java.io.EOFException` extends IOException, so the message branch is
+ *  reached for it too, but it is matched by type first for clarity. */
+internal fun isExpectedDisconnect(throwable: Throwable): Boolean {
+    var cause: Throwable? = throwable
+    while (cause != null) {
+        if (cause is java.nio.channels.ClosedChannelException ||
+            cause is kotlinx.coroutines.channels.ClosedReceiveChannelException ||
+            cause is kotlinx.coroutines.channels.ClosedSendChannelException ||
+            cause is java.io.EOFException
+        ) {
+            return true
+        }
+        if (cause is java.io.IOException) {
+            val message = cause.message?.lowercase().orEmpty()
+            if (message.contains("broken pipe") ||
+                message.contains("connection reset") ||
+                message.contains("connection abort") ||
+                message.contains("closed")
+            ) {
+                return true
+            }
+        }
+        cause = cause.cause
+    }
+    return false
+}
+
 internal data class EsphomeDeviceInfo(
     val name: String,
     val macAddress: String,
@@ -80,7 +112,11 @@ internal class EsphomeConnection(
             } catch (timeout: TimeoutCancellationException) {
                 log.i("idle client timed out", "afterMs" to idleTimeoutMs)
             } catch (throwable: Throwable) {
-                log.w("connection ended", throwable)
+                if (isExpectedDisconnect(throwable)) {
+                    log.i("client disconnected")
+                } else {
+                    log.w("connection ended", throwable)
+                }
             } finally {
                 stateJobs.forEach { it.cancel() }
                 cameraStreamJob?.cancel()

--- a/packages/esphome-server/src/main/kotlin/com/superdash/esphome/EsphomeServer.kt
+++ b/packages/esphome-server/src/main/kotlin/com/superdash/esphome/EsphomeServer.kt
@@ -116,7 +116,11 @@ internal class EsphomeServer(
                         } catch (timeout: TimeoutCancellationException) {
                             log.w("client setup timed out", null, "afterMs" to DEFAULT_IDLE_TIMEOUT_MS)
                         } catch (t: Throwable) {
-                            log.w("client setup failed", t)
+                            if (isExpectedDisconnect(t)) {
+                                log.i("client disconnected")
+                            } else {
+                                log.w("client setup failed", t)
+                            }
                         } finally {
                             runCatching { socket.close() }
                             runCatching { output.close() }

--- a/packages/esphome-server/src/test/kotlin/com/superdash/esphome/EsphomeExpectedDisconnectTest.kt
+++ b/packages/esphome-server/src/test/kotlin/com/superdash/esphome/EsphomeExpectedDisconnectTest.kt
@@ -1,0 +1,47 @@
+package com.superdash.esphome
+
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.EOFException
+import java.io.IOException
+import java.nio.channels.ClosedChannelException
+
+class EsphomeExpectedDisconnectTest {
+    @Test
+    fun `broken pipe is an expected disconnect`() {
+        assertTrue(isExpectedDisconnect(IOException("Broken pipe")))
+    }
+
+    @Test
+    fun `connection reset is an expected disconnect`() {
+        assertTrue(isExpectedDisconnect(IOException("Connection reset by peer")))
+    }
+
+    @Test
+    fun `closed channel is an expected disconnect`() {
+        assertTrue(isExpectedDisconnect(ClosedChannelException()))
+    }
+
+    @Test
+    fun `closed receive channel is an expected disconnect`() {
+        assertTrue(isExpectedDisconnect(ClosedReceiveChannelException("closed")))
+    }
+
+    @Test
+    fun `EOF is an expected disconnect`() {
+        assertTrue(isExpectedDisconnect(EOFException()))
+    }
+
+    @Test
+    fun `wrapped broken pipe in cause chain is an expected disconnect`() {
+        assertTrue(isExpectedDisconnect(RuntimeException("write failed", IOException("Broken pipe"))))
+    }
+
+    @Test
+    fun `a protocol bug is not an expected disconnect`() {
+        assertFalse(isExpectedDisconnect(IllegalStateException("bad frame")))
+        assertFalse(isExpectedDisconnect(IOException("disk full")))
+    }
+}


### PR DESCRIPTION
## Problem (root-caused on-device)

A user reported the ESPHome camera feed didn't show in Home Assistant and "person" motion detection did nothing. On-device diagnosis found a single root cause: the camera setting was **enabled** but the Android **CAMERA runtime permission was denied** (which happens after a reinstall, or after remote-enabling the camera over ESPHome). With permission denied the capture pipeline never starts — so the feed is dead and no detection runs. Nothing surfaced this or re-attempted capture once the permission was granted, because a same-value setting write is filtered by `distinctUntilChanged`. (Person detection itself was verified working — ML Kit face detection runs fine once the camera runs.)

Separately: HA closing a camera live-view logged a `java.io.IOException: Broken pipe` WARN stack trace — a normal disconnect, over-logged.

## Fix

- **Surface it:** when the camera is enabled but the permission is denied, Settings shows a **"Camera permission required — tap to grant"** row (the `camera_status` sensor already reports `PermissionMissing` to HA). The permission is re-checked on resume, so granting/revoking in Android settings is picked up.
- **Recover on grant:** `CameraController.requestRestart()` + `AppGraph.restartCameraCapture()` re-start the pipeline and the camera foreground service when the permission flips to granted while the camera is still enabled — invoked from `SettingsActivity`/`MainActivity.onResume` (availability-gated so it only fires when capture was blocked, no re-bind loop) and from the permission-result callback. No manual toggle needed. The permission dialog's **deny path no longer disables an enabled camera** (fixes Android 11+ silent auto-deny).
- **Quiet the log:** `isExpectedDisconnect()` classifies normal client disconnects (broken pipe / reset / closed / EOF) and logs them at info at **both** catch sites (`EsphomeConnection` and `EsphomeServer`), where the same exception otherwise surfaced twice.

## Test plan

- [x] Full gate green: `ktlintCheck testDebugUnitTest :packages:app:assembleDebug`. New unit tests: controller restart trigger, disconnect classifier (8), ViewModel permission flag.
- [ ] On-device (needs tablet + HA): with the camera enabled, `adb shell pm revoke com.superdash android.permission.CAMERA` → Settings shows the tap-to-grant row and `camera_status` = PermissionMissing; grant via the row (and via OS app-info → return to kiosk) → capture recovers to ~7.5 fps **without** toggling off/on; open/close a live-view in HA → logcat shows `client disconnected` (info), not a Broken pipe stack trace.

Note: 3 pre-existing `MissingTranslation` lint warnings for sidebar strings are unrelated to this change and not a CI gate (CI doesn't run Android lint); the new camera strings are translated in en/fr/nl.

https://claude.ai/code/session_01FSE258rBogcC1hDHUuxyrr