### PR TITLE
fix: low-effort HA-client & kiosk batch (#11, #12, #13, #18)

### DIFF
--- a/packages/app/src/main/kotlin/com/superdash/MainActivity.kt
+++ b/packages/app/src/main/kotlin/com/superdash/MainActivity.kt
@@ -192,6 +192,13 @@ class MainActivity : AppCompatActivity() {
 
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
         if (ev != null) {
+            // Reset the idle timer on any touch interaction. The GestureDetector
+            // only fires on tap/long-press, so swipes and scrolls would otherwise
+            // let the screensaver start mid-interaction. ACTION_DOWN begins every
+            // gesture, so resetting here covers them all.
+            if (ev.actionMasked == MotionEvent.ACTION_DOWN) {
+                graph.idleController.touch()
+            }
             tapDetector.onTouchEvent(ev)
         }
         return super.dispatchTouchEvent(ev)

--- a/packages/ha-client/src/main/kotlin/com/superdash/ha/HaWebSocketClient.kt
+++ b/packages/ha-client/src/main/kotlin/com/superdash/ha/HaWebSocketClient.kt
@@ -291,8 +291,17 @@ class HaWebSocketClient(
                     val pingJob =
                         launch {
                             runPingLoop(
-                                sendPing = { pingId -> session.sendCommand(PingCommand(pingId)) },
-                                awaitPong = { pingId -> pongs.first { it == pingId } },
+                                // The ping is sent from awaitPong's onSubscription so the
+                                // pong collector is attached before the ping goes out. Sending
+                                // in sendPing (before subscribing) lets a fast pong land while
+                                // pongs has replay=0 and no collector, causing a spurious
+                                // timeout/disconnect. Mirrors runPingLoopForTest.
+                                sendPing = { /* sent via onSubscription below */ },
+                                awaitPong = { pingId ->
+                                    pongs
+                                        .onSubscription { session.sendCommand(PingCommand(pingId)) }
+                                        .first { it == pingId }
+                                },
                                 onTimeout = { pingId ->
                                     log.w("ping timed out; closing websocket", null, "pingId" to pingId)
                                     session.cancel(CancellationException("HA websocket ping timed out"))
@@ -521,7 +530,11 @@ class HaWebSocketClient(
                 runCatching { json.decodeFromString<HaWsFrame>(text) }.getOrNull()
                     ?: continue
             when (parsed) {
-                is EventFrame -> _entities.update { applyEntityEvent(it, parsed.event) }
+                is EventFrame ->
+                    // A single malformed event (e.g. a state payload we can't decode)
+                    // must not tear down the whole connection. Log and skip it.
+                    runCatching { _entities.update { applyEntityEvent(it, parsed.event) } }
+                        .onFailure { t -> log.w("failed to apply state_changed event; skipping", t) }
                 is Pong -> pongs.tryEmit(parsed.id)
                 else -> { /* ignored */ }
             }
@@ -547,9 +560,10 @@ class HaWebSocketClient(
     }
 
     private fun recordRecent(line: String) {
+        val redacted = redactSecrets(line)
         val snapshot =
             synchronized(recentEventsLock) {
-                recentEventsBuffer.addFirst(line)
+                recentEventsBuffer.addFirst(redacted)
                 while (recentEventsBuffer.size > RECENT_EVENTS_CAP) {
                     recentEventsBuffer.removeLast()
                 }
@@ -559,6 +573,19 @@ class HaWebSocketClient(
     }
 
     internal val scopeForTest: CoroutineScope get() = scope
+
+    private companion object {
+        // Mask the access token in any frame we record for the debug screen so the
+        // long-lived HA token never shows up in recentEvents. The outbound auth
+        // frame is the obvious source, but redacting by field name catches the
+        // token wherever it appears regardless of direction. The value pattern
+        // consumes JSON escapes (\" \\ …) so a token containing an escaped quote
+        // is fully masked instead of leaking its tail.
+        private val ACCESS_TOKEN_REGEX = Regex("(\"access_token\"\\s*:\\s*\")(?:\\\\.|[^\"\\\\])*\"")
+
+        fun redactSecrets(line: String): String =
+            ACCESS_TOKEN_REGEX.replace(line) { match -> "${match.groupValues[1]}<redacted>\"" }
+    }
 
     internal val isAnyJobRefActiveForTest: Boolean
         get() = pingJobRef.get()?.isActive == true || runConnectionJobRef.get()?.isActive == true
@@ -589,6 +616,8 @@ class HaWebSocketClient(
     internal fun deliverPongForTest(pingId: Int) {
         pongs.tryEmit(pingId)
     }
+
+    internal fun redactSecretsForTest(line: String): String = redactSecrets(line)
 
     internal class NotAuthenticatedExceptionWrapper(
         cause: Throwable,

--- a/packages/ha-client/src/test/kotlin/com/superdash/ha/HaWebSocketClientRedactionTest.kt
+++ b/packages/ha-client/src/test/kotlin/com/superdash/ha/HaWebSocketClientRedactionTest.kt
@@ -1,0 +1,91 @@
+package com.superdash.ha
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/** The debug screen renders recentEvents verbatim, so the long-lived HA access
+ *  token must never survive into a recorded frame. */
+class HaWebSocketClientRedactionTest {
+    @Test
+    fun `access token in auth frame is redacted`() {
+        val client = newClient()
+        val line = "→ {\"type\":\"auth\",\"access_token\":\"eyJhbGc.super-secret.value\"}"
+
+        val redacted = client.redactSecretsForTest(line)
+
+        assertFalse("token leaked: $redacted", redacted.contains("super-secret"))
+        assertEquals(
+            "→ {\"type\":\"auth\",\"access_token\":\"<redacted>\"}",
+            redacted,
+        )
+    }
+
+    @Test
+    fun `access token is redacted with whitespace around the field`() {
+        val client = newClient()
+        val line = "{ \"access_token\" : \"tok-123\" }"
+
+        val redacted = client.redactSecretsForTest(line)
+
+        assertFalse(redacted.contains("tok-123"))
+        assertEquals("{ \"access_token\" : \"<redacted>\" }", redacted)
+    }
+
+    @Test
+    fun `token containing an escaped quote is fully redacted`() {
+        val client = newClient()
+        val line = "{\"access_token\":\"aa\\\"bb\",\"type\":\"auth\"}"
+
+        val redacted = client.redactSecretsForTest(line)
+
+        assertFalse("token tail leaked: $redacted", redacted.contains("bb"))
+        assertEquals("{\"access_token\":\"<redacted>\",\"type\":\"auth\"}", redacted)
+    }
+
+    @Test
+    fun `frames without a token are left unchanged`() {
+        val client = newClient()
+        val line = "← {\"type\":\"event\",\"event\":{\"entity_id\":\"light.kitchen\"}}"
+
+        assertEquals(line, client.redactSecretsForTest(line))
+    }
+
+    private fun newClient(): HaWebSocketClient {
+        val haUrl = MutableStateFlow<String?>(null)
+        val engine = MockEngine { _ -> respond(ByteReadChannel.Empty, HttpStatusCode.BadRequest) }
+        val httpClient = HttpClient(engine)
+        val tokens =
+            HaTokenProvider(
+                store = InMemoryHaTokenStore(),
+                httpClient = httpClient,
+                baseUrl = { haUrl.value ?: "" },
+            )
+        return HaWebSocketClient(haUrl = haUrl, tokens = tokens, httpClient = httpClient)
+    }
+
+    private class InMemoryHaTokenStore : HaTokenStoreLike {
+        private var tokens: HaTokens? =
+            HaTokens(
+                accessToken = "access",
+                refreshToken = "refresh",
+                expiresAtEpochMs = Long.MAX_VALUE / 2,
+            )
+
+        override suspend fun load(): HaTokens? = tokens
+
+        override suspend fun save(tokens: HaTokens) {
+            this.tokens = tokens
+        }
+
+        override suspend fun clear() {
+            tokens = null
+        }
+    }
+}


### PR DESCRIPTION
Batch of four independent, low-effort/high-impact fixes from the code-review backlog. Each maps to one issue.

| Issue | Type | Fix |
|-------|------|-----|
| #12 | security | Redact `access_token` values in `recordRecent` before they reach `recentEvents` / the WsDebug screen. Regex consumes JSON escapes so an escaped-quote token can't leak its tail. |
| #13 | robustness | Wrap `applyEntityEvent` in `runCatching` in `receiveLoop` — a malformed `state_changed` event is logged and skipped instead of killing the connection. |
| #11 | reliability | Send the keepalive ping from `awaitPong`'s `onSubscription` so the pong collector is attached first, avoiding a spurious pong-timeout disconnect (mirrors `runPingLoopForTest`). |
| #18 | UX | Reset the screensaver idle timer on `ACTION_DOWN` in `dispatchTouchEvent` so swipes/scrolls count, not just taps/long-presses. |

## Tests
- New `HaWebSocketClientRedactionTest` (4 cases, incl. escaped-quote token).
- `:packages:ha-client:testDebugUnitTest` green, `:packages:app:compileDebugKotlin` green, `ktlintCheck` clean.

## Review
Reviewed by a Fable agent before opening: all four fixes confirmed correct, no high/medium issues. The one low-severity note (redaction regex escaped-quote gap) is addressed in this PR.

Closes #12
Closes #13
Closes #11
Closes #18